### PR TITLE
feat: #86 프리뷰 템플릿 데이터 정적 저장 + 타입 정의

### DIFF
--- a/apps/web/src/components/preview/__tests__/param-substitute.test.ts
+++ b/apps/web/src/components/preview/__tests__/param-substitute.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractParamKeys,
+  substituteParams,
+} from "../param-substitute";
+
+describe("substituteParams", () => {
+  it("단일 파라미터를 치환해야 한다", () => {
+    expect(substituteParams("$$name$$", { name: "김코드" })).toBe("김코드");
+  });
+
+  it("여러 파라미터를 치환해야 한다", () => {
+    const result = substituteParams("$$monthNum$$/$$dayNum$$", {
+      monthNum: "04",
+      dayNum: "25",
+    });
+    expect(result).toBe("04/25");
+  });
+
+  it("동일 키가 여러 번 나오면 모두 치환해야 한다", () => {
+    const result = substituteParams("$$name$$ - $$name$$", { name: "test" });
+    expect(result).toBe("test - test");
+  });
+
+  it("정의되지 않은 키는 빈 문자열로 대체해야 한다", () => {
+    expect(substituteParams("$$missing$$", {})).toBe("");
+  });
+
+  it("일부만 정의된 경우 정의된 것만 치환하고 나머지는 빈 문자열", () => {
+    const result = substituteParams(
+      "$$defined$$ / $$missing$$",
+      { defined: "값" }
+    );
+    expect(result).toBe("값 / ");
+  });
+
+  it("$$ 패턴이 없으면 원본 그대로 반환해야 한다", () => {
+    expect(substituteParams("plain text", {})).toBe("plain text");
+  });
+
+  it("빈 문자열을 입력하면 빈 문자열을 반환해야 한다", () => {
+    expect(substituteParams("", { foo: "bar" })).toBe("");
+  });
+
+  it("줄바꿈 문자가 포함된 값도 정상 치환해야 한다", () => {
+    const result = substituteParams("$$msg$$", { msg: "줄1\n줄2\n줄3" });
+    expect(result).toBe("줄1\n줄2\n줄3");
+  });
+
+  it("파라미터 값이 빈 문자열이면 빈 문자열로 치환해야 한다", () => {
+    expect(substituteParams("$$key$$", { key: "" })).toBe("");
+  });
+
+  it("긴 텍스트와 짧은 키를 정확히 치환해야 한다", () => {
+    const long = "기능 구현보다 문제 정의가 더 중요하다는 점을 배웠습니다.";
+    const result = substituteParams(
+      "수료생 회고:\n\n$$diaryText$$",
+      { diaryText: long }
+    );
+    expect(result).toBe(`수료생 회고:\n\n${long}`);
+  });
+
+  it("$$ 만 있고 키가 없는 문자열은 변경하지 않아야 한다", () => {
+    expect(substituteParams("$$$$", {})).toBe("$$$$");
+  });
+
+  it("키 이름에 숫자가 포함된 경우 치환해야 한다", () => {
+    expect(substituteParams("$$key1$$", { key1: "값" })).toBe("값");
+  });
+
+  it("키 이름이 숫자로 시작하면 치환하지 않아야 한다", () => {
+    // PRD/SweetBook 패턴에 숫자로 시작하는 키 없음. 정규식이 [a-zA-Z]로 시작 강제.
+    expect(substituteParams("$$1key$$", { "1key": "값" })).toBe("$$1key$$");
+  });
+
+  // QA: 치환 값에 String.replace 특수 패턴이 있어도 리터럴로 처리
+  it("치환 값에 $& 특수 패턴이 있어도 리터럴로 처리되어야 한다", () => {
+    // String.replace의 두 번째 인자가 callback이면 특수 패턴 해석 없음
+    expect(substituteParams("$$key$$", { key: "$& 리터럴" })).toBe("$& 리터럴");
+  });
+
+  it("치환 값에 $1, $2 특수 패턴이 있어도 리터럴로 처리되어야 한다", () => {
+    expect(substituteParams("$$key$$", { key: "$1 $2 $3" })).toBe("$1 $2 $3");
+  });
+
+  it("치환 값에 $$ 가 있어도 리터럴로 처리되어야 한다", () => {
+    expect(substituteParams("$$key$$", { key: "$$" })).toBe("$$");
+  });
+});
+
+describe("extractParamKeys", () => {
+  it("단일 키를 추출해야 한다", () => {
+    expect(extractParamKeys("$$name$$")).toEqual(["name"]);
+  });
+
+  it("여러 키를 추출해야 한다", () => {
+    expect(extractParamKeys("$$a$$ $$b$$ $$c$$")).toEqual(["a", "b", "c"]);
+  });
+
+  it("중복된 키는 한 번만 반환해야 한다", () => {
+    expect(extractParamKeys("$$name$$ - $$name$$ - $$age$$")).toEqual([
+      "name",
+      "age",
+    ]);
+  });
+
+  it("키가 없으면 빈 배열을 반환해야 한다", () => {
+    expect(extractParamKeys("plain text")).toEqual([]);
+  });
+
+  it("빈 문자열은 빈 배열을 반환해야 한다", () => {
+    expect(extractParamKeys("")).toEqual([]);
+  });
+});

--- a/apps/web/src/components/preview/__tests__/templates.test.ts
+++ b/apps/web/src/components/preview/__tests__/templates.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import { extractParamKeys } from "../param-substitute";
+import { TEMPLATES, type TemplateKey } from "../templates";
+import type { TemplateData, TemplateElement } from "../types";
+
+// 5종 element 타입 (types.ts의 TemplateElement union과 일치해야 함)
+const VALID_ELEMENT_TYPES = new Set<string>([
+  "text",
+  "photo",
+  "graphic",
+  "rectangle",
+  "collageGallery",
+]);
+
+// 백엔드 payload-mapper(apps/api/src/lib/payload-mapper.ts)가 생성하는 파라미터 키 전체.
+// 이 집합과 templates.ts의 $$key$$가 일치해야 책이 정상 렌더링된다.
+const KNOWN_PARAM_KEYS = new Set<string>([
+  "monthNum",
+  "dayNum",
+  "diaryText",
+  "photo",
+  "collagePhotos",
+  "coverPhoto",
+  "subtitle",
+  "dateRange",
+]);
+
+const TEMPLATE_KEYS: TemplateKey[] = ["cover", "contentB", "contentA", "gallery"];
+
+// ────────────────────────────────────────────────
+// 기본 구조 검증
+// ────────────────────────────────────────────────
+
+describe("TEMPLATES 객체", () => {
+  it("4개 템플릿이 모두 존재해야 한다", () => {
+    expect(Object.keys(TEMPLATES)).toEqual([
+      "cover",
+      "contentB",
+      "contentA",
+      "gallery",
+    ]);
+  });
+
+  it.each(TEMPLATE_KEYS)("%s 템플릿이 templateUid를 가져야 한다", (key) => {
+    const template = TEMPLATES[key];
+    expect(template.templateUid).toBeTruthy();
+    expect(typeof template.templateUid).toBe("string");
+  });
+
+  it.each(TEMPLATE_KEYS)("%s 템플릿이 비어 있지 않아야 한다", (key) => {
+    const template = TEMPLATES[key];
+    expect(template.layout.elements.length).toBeGreaterThan(0);
+  });
+});
+
+// ────────────────────────────────────────────────
+// element 타입 정합성 (P0)
+// ────────────────────────────────────────────────
+
+describe("element 타입 정합성", () => {
+  it.each(TEMPLATE_KEYS)("%s 템플릿의 모든 element가 5종 union 중 하나여야 한다", (key) => {
+    const template: TemplateData = TEMPLATES[key];
+    for (const element of template.layout.elements) {
+      expect(VALID_ELEMENT_TYPES.has(element.type)).toBe(true);
+    }
+  });
+
+  it("5종 element 타입이 적어도 하나의 템플릿에서 사용되어야 한다 (커버리지 sanity)", () => {
+    const seenTypes = new Set<string>();
+    for (const key of TEMPLATE_KEYS) {
+      for (const element of TEMPLATES[key].layout.elements) {
+        seenTypes.add(element.type);
+      }
+    }
+    expect(seenTypes).toEqual(VALID_ELEMENT_TYPES);
+  });
+});
+
+// ────────────────────────────────────────────────
+// 파라미터 키 정합성 (P0 — 가장 중요)
+// ────────────────────────────────────────────────
+
+/**
+ * 템플릿 element에서 모든 $$key$$ 패턴을 추출한다.
+ * text 요소의 text 필드, photo 요소의 fileName 필드,
+ * collageGallery 요소의 photos 필드를 모두 검사한다.
+ */
+function extractAllParamKeys(template: TemplateData): string[] {
+  const keys = new Set<string>();
+  for (const element of template.layout.elements) {
+    const sources: string[] = [];
+    if (element.type === "text") sources.push(element.text);
+    if (element.type === "photo") sources.push(element.fileName);
+    if (element.type === "collageGallery") sources.push(element.photos);
+    for (const source of sources) {
+      for (const key of extractParamKeys(source)) {
+        keys.add(key);
+      }
+    }
+  }
+  return Array.from(keys);
+}
+
+describe("파라미터 키 정합성 (templates ↔ payload-mapper)", () => {
+  it.each(TEMPLATE_KEYS)("%s 템플릿의 모든 $$key$$가 알려진 파라미터 집합에 속해야 한다", (key) => {
+    const template = TEMPLATES[key];
+    const usedKeys = extractAllParamKeys(template);
+
+    for (const paramKey of usedKeys) {
+      expect(
+        KNOWN_PARAM_KEYS.has(paramKey),
+        `템플릿 ${key}에 알려지지 않은 파라미터 $$${paramKey}$$가 있음. payload-mapper(apps/api)의 파라미터 키 집합과 동기화 필요.`
+      ).toBe(true);
+    }
+  });
+
+  it("cover 템플릿은 coverPhoto, subtitle, dateRange를 사용해야 한다", () => {
+    const usedKeys = new Set(extractAllParamKeys(TEMPLATES.cover));
+    expect(usedKeys.has("coverPhoto")).toBe(true);
+    expect(usedKeys.has("subtitle")).toBe(true);
+    expect(usedKeys.has("dateRange")).toBe(true);
+  });
+
+  it("contentB 템플릿은 monthNum, dayNum, diaryText를 사용해야 한다", () => {
+    const usedKeys = new Set(extractAllParamKeys(TEMPLATES.contentB));
+    expect(usedKeys.has("monthNum")).toBe(true);
+    expect(usedKeys.has("dayNum")).toBe(true);
+    expect(usedKeys.has("diaryText")).toBe(true);
+  });
+
+  it("contentA 템플릿은 monthNum, dayNum, diaryText, photo를 사용해야 한다", () => {
+    const usedKeys = new Set(extractAllParamKeys(TEMPLATES.contentA));
+    expect(usedKeys.has("monthNum")).toBe(true);
+    expect(usedKeys.has("dayNum")).toBe(true);
+    expect(usedKeys.has("diaryText")).toBe(true);
+    expect(usedKeys.has("photo")).toBe(true);
+  });
+
+  it("gallery 템플릿은 monthNum, dayNum, collagePhotos를 사용해야 한다", () => {
+    const usedKeys = new Set(extractAllParamKeys(TEMPLATES.gallery));
+    expect(usedKeys.has("monthNum")).toBe(true);
+    expect(usedKeys.has("dayNum")).toBe(true);
+    expect(usedKeys.has("collagePhotos")).toBe(true);
+  });
+});
+
+// ────────────────────────────────────────────────
+// 데이터 sanity 검증 (P2)
+// ────────────────────────────────────────────────
+
+describe("데이터 sanity", () => {
+  it.each(TEMPLATE_KEYS)("%s 템플릿의 모든 element가 양수 width/height를 가져야 한다", (key) => {
+    const template = TEMPLATES[key];
+    for (const element of template.layout.elements) {
+      expect(element.width).toBeGreaterThan(0);
+      expect(element.height).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(TEMPLATE_KEYS)("%s 템플릿의 모든 element가 음수가 아닌 position을 가져야 한다", (key) => {
+    const template = TEMPLATES[key];
+    for (const element of template.layout.elements) {
+      expect(element.position.x).toBeGreaterThanOrEqual(0);
+      expect(element.position.y).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it.each(TEMPLATE_KEYS)("%s 템플릿의 element_id가 모두 unique해야 한다", (key) => {
+    const template = TEMPLATES[key];
+    const ids = template.layout.elements.map((e: TemplateElement) => e.element_id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+});

--- a/apps/web/src/components/preview/constants.ts
+++ b/apps/web/src/components/preview/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * 책 프리뷰 렌더러 상수
+ *
+ * SweetBook 템플릿 좌표 단위는 추정 pt. 실제 인쇄 dpi와 무관하게
+ * 좌표/크기의 비율만 유지하면 되므로, 단위는 의미가 없고 비율만 중요.
+ */
+
+/** 단일 내지 페이지 너비 (SweetBook 템플릿 좌표 단위) */
+export const PAGE_WIDTH = 864;
+
+/** 단일 내지 페이지 높이 */
+export const PAGE_HEIGHT = 1212;
+
+/** 표지 스프레드 너비 (뒷표지 + 책등 + 앞표지) */
+export const COVER_SPREAD_WIDTH = 1716;
+
+/**
+ * Graphic 요소 fallback 색상 — #85 검증에서 외부 이미지 접근 불가 확인.
+ * 일기장A 테마(토프 계열)와 조화되는 색상.
+ */
+export const GRAPHIC_FALLBACK_COLOR = "#8B7D6B";

--- a/apps/web/src/components/preview/param-substitute.ts
+++ b/apps/web/src/components/preview/param-substitute.ts
@@ -1,0 +1,39 @@
+import type { ParamValues } from "./types";
+
+const PARAM_PATTERN = /\$\$([a-zA-Z][a-zA-Z0-9_]*)\$\$/g;
+
+/**
+ * 템플릿 텍스트의 `$$paramName$$` 패턴을 실제 값으로 치환한다.
+ *
+ * 정의되지 않은 키는 빈 문자열로 대체한다 (PRD §6 예외 처리: "파라미터 값이 null → 빈 문자열").
+ *
+ * @example
+ * substituteParams("$$monthNum$$/$$dayNum$$", { monthNum: "04", dayNum: "25" })
+ * // → "04/25"
+ *
+ * @example
+ * substituteParams("$$missing$$", {})
+ * // → ""
+ */
+export function substituteParams(text: string, params: ParamValues): string {
+  return text.replace(PARAM_PATTERN, (_match, key: string) => {
+    return params[key] ?? "";
+  });
+}
+
+/**
+ * 텍스트에서 사용된 모든 파라미터 키를 추출한다.
+ * 디버깅·검증용. 동일한 키가 여러 번 나오면 한 번만 반환.
+ *
+ * @example
+ * extractParamKeys("$$name$$ - $$name$$ ($$age$$)")
+ * // → ["name", "age"]
+ */
+export function extractParamKeys(text: string): string[] {
+  const matches = text.matchAll(PARAM_PATTERN);
+  const seen = new Set<string>();
+  for (const match of matches) {
+    seen.add(match[1]);
+  }
+  return Array.from(seen);
+}

--- a/apps/web/src/components/preview/templates.ts
+++ b/apps/web/src/components/preview/templates.ts
@@ -1,0 +1,397 @@
+// AUTO-IMPORTED from SweetBook /v1/templates/{uid} responses (#85 검증 시 캐시).
+// 이 데이터는 build-time에 정적으로 저장된다 (PRD §4.2):
+//   1. 템플릿 레이아웃은 자주 변경되지 않음
+//   2. 런타임 API 호출 지연 회피
+//   3. SweetBook API key를 프론트엔드에 노출하지 않음
+//
+// graphic 요소의 imageSource는 #85 검증에서 외부 접근 불가로 확인되었으므로,
+// 렌더러는 이를 무시하고 GRAPHIC_FALLBACK_COLOR로 대체한다.
+
+import type { TemplateData } from "./types";
+
+export const cover: TemplateData = {
+  "templateUid": "3S1ceGaglj5i",
+  "templateName": "표지 (A4 소프트커버 포토북)",
+  "theme": "구글포토북A",
+  "layout": {
+    "backgroundColor": "#FFFFFFFF",
+    "elements": [
+      {
+        "element_id": "book-back",
+        "type": "rectangle",
+        "position": {
+          "x": 851.1747617761661,
+          "y": 0
+        },
+        "width": 39.65047644766792,
+        "height": 1212,
+        "color": "#FFFFFFFF",
+        "logoImage": "Transparent",
+        "logoHeight": 28
+      },
+      {
+        "element_id": "back-star",
+        "type": "graphic",
+        "position": {
+          "x": 414.98591875313457,
+          "y": 591.3785154449055
+        },
+        "width": 21.00131167779021,
+        "height": 21.00131167779021,
+        "imageSource": "/api_platform_image/public/image260312122533797.PNG",
+        "opacity": 1,
+        "graphicType": "Sticker"
+      },
+      {
+        "element_id": "front-photo",
+        "type": "photo",
+        "position": {
+          "x": 1171.3439585664132,
+          "y": 86.94208588428482
+        },
+        "width": 505.4091663130281,
+        "height": 1034.4234670355004,
+        "fileName": "$$coverPhoto$$",
+        "fit": "cover"
+      },
+      {
+        "element_id": "front-title",
+        "type": "text",
+        "position": {
+          "x": 940.967969985726,
+          "y": 81.88497003227295
+        },
+        "width": 263.9024825431118,
+        "height": 295.86387736284007,
+        "text": "ONE FINE\nDAY",
+        "fontFamily": "Impact",
+        "fontSize": 54,
+        "textBold": false,
+        "textBrush": "#FF000000",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "textLineHeight": 76,
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "front-subtitle",
+        "type": "text",
+        "position": {
+          "x": 942.4632633771847,
+          "y": 1060.2788151221762
+        },
+        "width": 224.97445121715984,
+        "height": 46.146150299677274,
+        "text": "$$subtitle$$",
+        "fontFamily": "배달의민족 도현",
+        "fontSize": 15,
+        "textBold": false,
+        "textBrush": "#FF000000",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "front-daterange",
+        "type": "text",
+        "position": {
+          "x": 942.4632633771847,
+          "y": 1082.262988186487
+        },
+        "width": 224.97445121715984,
+        "height": 46.146150299677274,
+        "text": "$$dateRange$$",
+        "fontFamily": "Roboto",
+        "fontSize": 12,
+        "textBold": false,
+        "textBrush": "#FF666666",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "isDynamic": false,
+        "splittable": false
+      }
+    ]
+  }
+} as const;
+
+export const contentB: TemplateData = {
+  "templateUid": "3mjKd8kcaVzT",
+  "templateName": "내지b (A4 소프트커버 포토북)",
+  "theme": "일기장A",
+  "layout": {
+    "backgroundColor": "#FFFFFFFF",
+    "elements": [
+      {
+        "element_id": "divider",
+        "type": "graphic",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 202.86331288343558,
+        "height": 1212,
+        "imageSource": "/api_platform_image/public/image260312122639465.PNG",
+        "opacity": 1,
+        "graphicType": "Sticker"
+      },
+      {
+        "element_id": "month-num",
+        "type": "text",
+        "position": {
+          "x": 50.0201226993865,
+          "y": 81.23874896477804
+        },
+        "width": 103.51214723926381,
+        "height": 89.61630695443645,
+        "text": "$$monthNum$$",
+        "fontFamily": "DM Serif Display",
+        "fontSize": 65,
+        "textBold": false,
+        "textBrush": "#FFFFFFFF",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "day-num",
+        "type": "text",
+        "position": {
+          "x": 50.0201226993865,
+          "y": 176.31937448238898
+        },
+        "width": 103.51214723926381,
+        "height": 89.61630695443645,
+        "text": "$$dayNum$$",
+        "fontFamily": "DM Serif Display",
+        "fontSize": 65,
+        "textBold": false,
+        "textBrush": "#FFFFFFFF",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "diary-text",
+        "type": "text",
+        "position": {
+          "x": 235.4885889570552,
+          "y": 93.57637889688249
+        },
+        "width": 584.4633128834356,
+        "height": 1025.634412470024,
+        "text": "$$diaryText$$",
+        "fontFamily": "NanumMyeongjo",
+        "fontSize": 12,
+        "textBold": false,
+        "textBrush": "#FF3F3F3F",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "textLineHeight": 26,
+        "isDynamic": false,
+        "splittable": false
+      }
+    ]
+  }
+} as const;
+
+export const contentA: TemplateData = {
+  "templateUid": "3nWJ4wtPSQOb",
+  "templateName": "내지a (A4 소프트커버 포토북)",
+  "theme": "일기장A",
+  "layout": {
+    "backgroundColor": "#FFFFFFFF",
+    "elements": [
+      {
+        "element_id": "bg-taupe",
+        "type": "rectangle",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 864,
+        "height": 508.58465227817743,
+        "color": "#FF9A9088"
+      },
+      {
+        "element_id": "month-num",
+        "type": "text",
+        "position": {
+          "x": 40.56736196319019,
+          "y": 69.35575539568346
+        },
+        "width": 103.51214723926381,
+        "height": 89.61630695443645,
+        "text": "$$monthNum$$",
+        "fontFamily": "DM Serif Display",
+        "fontSize": 65,
+        "textBold": false,
+        "textBrush": "#FFFFFFFF",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "day-num",
+        "type": "text",
+        "position": {
+          "x": 40.56736196319019,
+          "y": 158.97206235011993
+        },
+        "width": 103.51214723926381,
+        "height": 89.61630695443645,
+        "text": "$$dayNum$$",
+        "fontFamily": "DM Serif Display",
+        "fontSize": 65,
+        "textBold": false,
+        "textBrush": "#FFFFFFFF",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "photo",
+        "type": "photo",
+        "position": {
+          "x": 191.24613496932514,
+          "y": 93.57637889688249
+        },
+        "width": 598.7838036809816,
+        "height": 385.6196319018405,
+        "fileName": "$$photo$$",
+        "fit": "cover",
+        "borderBrush": "#FFFFFFFF",
+        "verticalAlignment": "Bottom"
+      },
+      {
+        "element_id": "diary-text",
+        "type": "text",
+        "position": {
+          "x": 191.24613496932514,
+          "y": 532.692418384311
+        },
+        "width": 598.801472392638,
+        "height": 502.26306954436455,
+        "text": "$$diaryText$$",
+        "fontFamily": "NanumMyeongjo",
+        "fontSize": 12,
+        "textBold": false,
+        "textBrush": "#FF3F3F3F",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Left",
+        "verticalAlignment": "Top",
+        "textLineHeight": 26,
+        "isDynamic": false,
+        "splittable": false
+      }
+    ]
+  }
+} as const;
+
+export const gallery: TemplateData = {
+  "templateUid": "msFsr6Ult7qw",
+  "templateName": "내지_gallery (A4 소프트커버 포토북)",
+  "theme": "일기장A",
+  "layout": {
+    "backgroundColor": "#FFFFFFFF",
+    "elements": [
+      {
+        "element_id": "left-divider",
+        "type": "graphic",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 202.86331288343558,
+        "height": 1212,
+        "imageSource": "/api_platform_image/public/image260312122639465.PNG",
+        "opacity": 1,
+        "graphicType": "Sticker"
+      },
+      {
+        "element_id": "month-num",
+        "type": "text",
+        "position": {
+          "x": 42.298895705521474,
+          "y": 96
+        },
+        "width": 103.51214723926381,
+        "height": 89.61630695443645,
+        "text": "$$monthNum$$",
+        "fontFamily": "DM Serif Display",
+        "fontSize": 65,
+        "textBold": false,
+        "textBrush": "#FFFFFFFF",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Center",
+        "verticalAlignment": "Center",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "day-num",
+        "type": "text",
+        "position": {
+          "x": 42.298895705521474,
+          "y": 179.61630695443645
+        },
+        "width": 103.51214723926381,
+        "height": 89.61630695443645,
+        "text": "$$dayNum$$",
+        "fontFamily": "DM Serif Display",
+        "fontSize": 65,
+        "textBold": false,
+        "textBrush": "#FFFFFFFF",
+        "backgroundColor": "#00FFFFFF",
+        "textAlignment": "Center",
+        "verticalAlignment": "Center",
+        "isDynamic": false,
+        "splittable": false
+      },
+      {
+        "element_id": "collage",
+        "type": "collageGallery",
+        "position": {
+          "x": 216.44171779141104,
+          "y": 87.43645083932854
+        },
+        "width": 634.3067484662577,
+        "height": 1036.642685851319,
+        "tag": "collageGallery",
+        "photos": "$$collagePhotos$$",
+        "fit": "cover",
+        "verticalAlignment": "Top",
+        "container": {
+          "maxWidth": 864,
+          "maxHeight": 513.4772182254196,
+          "itemGap": 8.83435582822086
+        },
+        "isDynamic": false,
+        "layout": "auto",
+        "gap": 10
+      }
+    ]
+  }
+} as const;
+
+export const TEMPLATES = {
+  cover,
+  contentB,
+  contentA,
+  gallery,
+} as const;
+
+export type TemplateKey = keyof typeof TEMPLATES;

--- a/apps/web/src/components/preview/types.ts
+++ b/apps/web/src/components/preview/types.ts
@@ -1,0 +1,157 @@
+/**
+ * SweetBook 템플릿 레이아웃 데이터의 타입 정의.
+ *
+ * SweetBook /v1/templates/{uid} 응답의 layout.elements를 그대로 반영한 구조.
+ * #85 검증에서 graphic 요소의 imageSource는 외부 접근 불가로 확인되어,
+ * 렌더링 시 fallback 색상으로 대체된다 (PRD §3.4).
+ */
+
+export interface ElementPosition {
+  x: number;
+  y: number;
+}
+
+export interface BaseElement {
+  element_id: string;
+  position: ElementPosition;
+  width: number;
+  height: number;
+}
+
+// ────────────────────────────────────────────────
+// Text element
+// ────────────────────────────────────────────────
+
+export type TextAlignment = "Left" | "Center" | "Right" | "Justify";
+export type VerticalAlignment = "Top" | "Center" | "Bottom";
+
+export interface TextElement extends BaseElement {
+  type: "text";
+  /** "$$paramName$$" 패턴 또는 정적 텍스트 */
+  text: string;
+  fontFamily: string;
+  fontSize: number;
+  textBold: boolean;
+  /** ARGB 형식 (#AARRGGBB) */
+  textBrush: string;
+  /** ARGB 형식 (#AARRGGBB) */
+  backgroundColor: string;
+  textAlignment: TextAlignment;
+  verticalAlignment: VerticalAlignment;
+  textLineHeight?: number;
+  isDynamic: boolean;
+  splittable: boolean;
+}
+
+// ────────────────────────────────────────────────
+// Photo element
+// ────────────────────────────────────────────────
+
+export type PhotoFit = "cover" | "contain" | "fill";
+
+export interface PhotoElement extends BaseElement {
+  type: "photo";
+  /** "$$paramName$$" 패턴 (예: "$$coverPhoto$$") */
+  fileName: string;
+  fit: PhotoFit;
+  borderBrush?: string;
+  verticalAlignment?: VerticalAlignment;
+}
+
+// ────────────────────────────────────────────────
+// Graphic element
+//
+// #85 검증 결과 imageSource는 외부 접근 불가.
+// 렌더링 시 GraphicElement 컴포넌트가 imageSource를 무시하고
+// GRAPHIC_FALLBACK_COLOR 단색 div로 대체한다.
+// ────────────────────────────────────────────────
+
+export interface GraphicElement extends BaseElement {
+  type: "graphic";
+  imageSource: string;
+  opacity: number;
+  graphicType: string;
+}
+
+// ────────────────────────────────────────────────
+// Rectangle element
+// ────────────────────────────────────────────────
+
+export interface RectangleElement extends BaseElement {
+  type: "rectangle";
+  /** ARGB 형식 (#AARRGGBB) */
+  color: string;
+  logoImage?: string;
+  logoHeight?: number;
+}
+
+// ────────────────────────────────────────────────
+// CollageGallery element
+//
+// #85 검증 결과 SweetBook의 layout:"auto"는 블랙박스이므로,
+// 렌더링 시 사진 수별 정적 grid-template-columns 규칙을 적용한다 (PRD §2.3).
+// ────────────────────────────────────────────────
+
+export interface CollageContainer {
+  maxWidth: number;
+  maxHeight: number;
+  itemGap: number;
+}
+
+export interface CollageGalleryElement extends BaseElement {
+  type: "collageGallery";
+  tag: string;
+  /** "$$paramName$$" 패턴 (예: "$$collagePhotos$$") */
+  photos: string;
+  fit: PhotoFit;
+  verticalAlignment: VerticalAlignment;
+  container: CollageContainer;
+  isDynamic: boolean;
+  /** SweetBook 내부 알고리즘 식별자 — 렌더러는 이를 무시하고 자체 그리드 규칙 사용 */
+  layout: string;
+  gap: number;
+}
+
+// ────────────────────────────────────────────────
+// Discriminated union
+// ────────────────────────────────────────────────
+
+export type TemplateElement =
+  | TextElement
+  | PhotoElement
+  | GraphicElement
+  | RectangleElement
+  | CollageGalleryElement;
+
+// ────────────────────────────────────────────────
+// Template
+// ────────────────────────────────────────────────
+
+export interface TemplateLayout {
+  /** ARGB 형식 (#AARRGGBB) */
+  backgroundColor: string;
+  elements: TemplateElement[];
+}
+
+export interface TemplateData {
+  templateUid: string;
+  templateName: string;
+  /** 일기장A, 구글포토북A 등 */
+  theme: string;
+  layout: TemplateLayout;
+}
+
+// ────────────────────────────────────────────────
+// Parameter substitution
+// ────────────────────────────────────────────────
+
+/**
+ * 템플릿 텍스트 내 `$$paramName$$` 패턴을 치환할 값들.
+ *
+ * 페이지 타입에 따라 키가 달라진다:
+ * - 모든 페이지: monthNum, dayNum, diaryText
+ * - 표지: coverPhoto, subtitle, dateRange
+ * - 내지a: + photo
+ * - 내지_gallery: + collagePhotos (JSON 배열 문자열)
+ */
+export type ParamValues = Record<string, string>;

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,12 @@
 # 프로젝트 현황
 
-**최종 업데이트:** 2026-04-08 (#85 프리뷰 선행 검증)
+**최종 업데이트:** 2026-04-08 (#86 프리뷰 템플릿 데이터 정적 저장)
 **현재 버전:** v0.1.0
 **배포 URL:** 없음
 
 ## 최근 변경
 
+- **#86 프리뷰 템플릿 데이터 정적 저장:** `apps/web/src/components/preview/` 신규 디렉토리. types.ts(5종 element discriminated union), constants.ts(PAGE_WIDTH/HEIGHT, GRAPHIC_FALLBACK_COLOR), templates.ts(4개 템플릿 정적 저장 — cover/contentB/contentA/gallery), param-substitute.ts(`$$key$$` 치환 유틸). QA에서 templates.ts ↔ payload-mapper 파라미터 8종 정합성 테스트 추가 — #87 구현 시 가정 일치 보장. 테스트 228개(+37).
 - **#85 책 프리뷰 선행 검증:** 3개 외부 의존성 확인. (1) 그래픽 이미지(`/api_platform_image/...`) 외부 접근 **불가** → CSS 단색 div 대체 결정. (2) Google Fonts 6종(Do Hyeon, Nanum Myeongjo, DM Serif Display 등) 모두 **가용**. (3) collageGallery는 PRD가 가정한 `flow.columns` 대신 `layout:"auto"` 블랙박스 — 사진 수별 정적 그리드 규칙으로 fallback. `/v1/templates/{uid}` 엔드포인트는 정상 동작 확인되어 #86 templates.ts 정적 저장 가능.
 - **#84 EditForm 새 블록 타입 UI:** PageBlockList 공통 컴포넌트 추출 (라벨 + 설명 + 토글 + 순서 변경 통합). EditForm의 레거시 토글 섹션 2개 + 페이지 순서 섹션을 PageBlockList 1개로 통합 (~80줄 단순화). CohortEditForm에 페이지 섹션 신규 추가. **#83 머지 후 발생한 회귀 버그 수정**: EditForm 토글이 레거시 ID(`project:N`)를 사용해 새 ID(`project-summary:N`)와 매칭 안 되던 문제 해결. getPageDescription 헬퍼 + PAGE_TYPE_DESCRIPTIONS 상수. 테스트 173개(+25), 린트/타입체크 통과.
 - **#83 프론트엔드 블록 ID 확장:** edit-session.ts에 PageBlockType 12종 + buildBlockId + getPageLabel 중앙화 + buildDefaultPages PRD 구성표 기반 리팩토링 (individual/cohort-showcase 분기). 레거시 시그니처 하위 호환 유지. EditForm.tsx 호출부 새 시그니처 전환. 테스트 148개(+17), 린트/타입체크 통과.
@@ -82,7 +83,7 @@
 
 ### Epic: 책 프리뷰 렌더러 (#85~#88)
 - [x] `#85` 프리뷰 선행 검증 [S] — 독립 (동시 시작 가능)
-- [ ] `#86` 템플릿 레이아웃 데이터 정적 저장 [M] → depends: #85
+- [x] `#86` 템플릿 레이아웃 데이터 정적 저장 [M] → depends: #85
 - [ ] `#87` PageRenderer 컴포넌트 [L] → depends: #86
 - [ ] `#88` BookPreview + EditForm 연결 [M] → depends: #87, #82
 


### PR DESCRIPTION
## 📌 변경 요약

#85 검증으로 확정된 4개 SweetBook 템플릿(cover, contentB, contentA, gallery)의 layout 데이터를 \`apps/web/src/components/preview/\`에 정적으로 저장하고, 5종 element discriminated union 타입과 \$\$paramName\$\$ 치환 유틸을 추가. #87 PageRenderer가 사용할 기반 마련.

## 🔗 관련 이슈 / PRD

Closes #86
PRD: \`docs/prd/book-preview-renderer.md\` (섹션 4.2)
선행 검증: \`docs/devlog/2026-04-08-issue-85-preview-verification.md\`

## 🧱 변경 범위

- [x] 새로운 기능 (feature)

## 🔧 주요 변경점

**\`apps/web/src/components/preview/\` 신규 디렉토리 (5개 파일):**
- \`types.ts\` — TemplateElement 5종 discriminated union (text/photo/graphic/rectangle/collageGallery), TemplateData, ParamValues
- \`constants.ts\` — PAGE_WIDTH=864, PAGE_HEIGHT=1212, COVER_SPREAD_WIDTH=1716, GRAPHIC_FALLBACK_COLOR=#8B7D6B
- \`templates.ts\` — 4개 템플릿 정적 저장 (sandbox \`/v1/templates/{uid}\` 응답에서 추출)
- \`param-substitute.ts\` — substituteParams + extractParamKeys
- \`__tests__/\` — templates 정합성 18개 + param-substitute 21개

**핵심 정합성 보장:**
- QA가 추가한 정합성 테스트가 templates.ts의 모든 \`\$\$key\$\$\` 패턴이 백엔드 payload-mapper(#82)의 파라미터 8종(monthNum, dayNum, diaryText, photo, collagePhotos, coverPhoto, subtitle, dateRange)과 일치함을 검증. 이 정합성이 깨지면 #87 구현 시 책이 빈 문자열로 렌더링되는데, 컴파일 에러가 안 나서 발견하기 어려운 종류의 버그를 사전 차단.

## 🧪 검증

- [x] 로컬에서 정상 동작을 확인했습니다
- [x] 관련 테스트를 추가하거나 업데이트했습니다
- [x] 문서를 업데이트했습니다 (해당하는 경우)

수동 검증: 린트(\`pnpm lint\`) + 타입체크(\`tsc --noEmit\`) 통과

자동 검증: 228개 테스트 통과 (templates 18개 + param-substitute 21개 신규)

## 📸 UI / API 영향

- UI 변경: 없음 (#87에서 PageRenderer가 사용)
- API 변경: 없음
- 데이터 모델 변경: 없음

## ✅ 체크리스트

- [x] 로컬에서 정상 동작을 확인했습니다
- [x] 관련 테스트를 추가하거나 업데이트했습니다
- [x] 문서를 업데이트했습니다 (해당하는 경우)

## ⚠️ 주의사항

- templates.ts는 graphic 요소의 \`imageSource\` 필드를 그대로 보존하지만, #85 검증에 따라 #87 \`GraphicElement\` 컴포넌트에서 의도적으로 무시하고 GRAPHIC_FALLBACK_COLOR로 대체할 예정.