### PR TITLE
feat: #88 BookPreview + CRUD 관리 UI + 회귀 fix 3건

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 
 ## 주요 기능
 
+- **CRUD 관리** — 기수·수료생·프로젝트를 운영자 화면에서 직접 추가/수정/삭제 (#77~#79)
 - 기수 목록 및 수료생 목록 조회
 - 수료생 상세 포트폴리오 확인
 - **개인 포트폴리오 북** 또는 **기수 쇼케이스 북** 선택
-- 편집 폼 — 표지 제목, 기념 수료 문구, 콘텐츠 블록 포함/제외, 페이지 순서 변경
+- 편집 폼 — 표지 제목, 기념 수료 문구, 12종 페이지 타입별 포함/제외, 페이지 순서 변경 (#82~#84)
+- **책 프리뷰** — SweetBook 템플릿 좌표를 HTML/CSS로 렌더링하여 책을 만들기 전에 페이지별로 미리 확인 (#85~#88)
 - 편집 완료 후 SweetBook API를 통한 책 생성 (4단계: 초안 → 표지 → 내지 → 최종화)
 - 책 생성 성공 후 배송 정보 입력 및 주문 생성
 - 주문 성공/실패 결과 표시
@@ -100,6 +102,9 @@ pnpm dev:web
 │   └── web        # Next.js + TypeScript 프론트엔드
 │       └── src
 │           ├── app/           # Next.js App Router 페이지
+│           ├── components/
+│           │   ├── admin/     # CRUD 폼/모달/패널 (#77~#79 UI)
+│           │   └── preview/   # PageRenderer + 5종 element + BookPreview (#85~#88)
 │           └── lib/           # api.ts, edit-session.ts, book-types.ts
 ├── docs
 │   ├── decisions  # ADR 문서

--- a/apps/api/src/lib/sweetbook-api.ts
+++ b/apps/api/src/lib/sweetbook-api.ts
@@ -106,7 +106,24 @@ export function createSweetBookClient(
       const form = new FormData();
       form.append("templateUid", payload.templateUid);
       if (Object.keys(payload.parameters).length > 0) {
-        form.append("parameters", JSON.stringify(payload.parameters));
+        // collageGallery 파라미터(예: collagePhotos)는 payload-mapper에서
+        // JSON 문자열로 들어오는데, 그대로 stringify하면 이중 인코딩되어
+        // SweetBook이 빈 배열로 인식한다. JSON 문자열이면 parse해서 객체로 풀어준다.
+        const params: Record<string, unknown> = { ...payload.parameters };
+        for (const key of Object.keys(params)) {
+          const value = params[key];
+          if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
+            try {
+              const parsed: unknown = JSON.parse(value);
+              if (Array.isArray(parsed)) {
+                params[key] = parsed;
+              }
+            } catch {
+              // JSON이 아닌 문자열이면 그대로 둠
+            }
+          }
+        }
+        form.append("parameters", JSON.stringify(params));
       }
       const response = await fetch(`${baseUrl}/books/${bookUid}/contents`, {
         method: "POST",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,6 +9,12 @@ import { getEnv, loadEnv } from "./config/env.js";
 import { getPrisma } from "./lib/prisma.js";
 import { orchestrateBook, OrchestrationError } from "./lib/orchestrate-book.js";
 import type { OrchestrationInput } from "./lib/orchestrate-book.js";
+import {
+  buildContentsPayload,
+  buildCoverPayload,
+} from "./lib/payload-mapper.js";
+import type { EditSessionInput } from "./lib/payload-mapper.js";
+import type { Cohort, StudentPortfolio } from "./data/cohorts.js";
 import { createSweetBookClient } from "./lib/sweetbook-api.js";
 import type { OrderShipping } from "./lib/sweetbook-api.js";
 
@@ -20,6 +26,81 @@ const port = env.PORT;
 
 function formatDate(date: Date): string {
   return date.toISOString().slice(0, 10);
+}
+
+/**
+ * DB에서 cohort + students + projects를 조회하여 Cohort 형태로 변환한다.
+ * /api/books와 /api/preview-payload에서 공통으로 사용.
+ */
+async function loadCohortFromDb(cohortId: string): Promise<Cohort | null> {
+  const db = getPrisma();
+  const cohortRow = await db.cohort.findUnique({ where: { id: cohortId } });
+  if (!cohortRow) return null;
+
+  const studentRows = await db.student.findMany({
+    where: { cohortId },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const studentsWithProjects: StudentPortfolio[] = await Promise.all(
+    studentRows.map(async (s: {
+      id: string; name: string; roleTrack: string; bio: string;
+      techStack: string[]; mentorComment: string; photos: string[];
+      certificateMessage: string; retrospective: unknown;
+      interests: string[]; achievements: string | null;
+      portfolioLinks: unknown; thanksMessage: string | null;
+    }) => {
+      const projects = await db.project.findMany({
+        where: { studentId: s.id },
+        orderBy: { createdAt: "asc" },
+      });
+      return {
+        id: s.id,
+        name: s.name,
+        roleTrack: s.roleTrack,
+        bio: s.bio,
+        techStack: s.techStack,
+        projects: projects.map((p: {
+          title: string; summary: string; contribution: string; links: string[];
+          problem: string | null; solution: string | null; techChoices: string[]; result: string | null;
+        }) => ({
+          title: p.title,
+          summary: p.summary,
+          contribution: p.contribution,
+          links: p.links,
+          ...(p.problem && { problem: p.problem }),
+          ...(p.solution && { solution: p.solution }),
+          ...(p.techChoices.length > 0 && { techChoices: p.techChoices }),
+          ...(p.result && { result: p.result }),
+        })),
+        retrospective: typeof s.retrospective === "object" && s.retrospective !== null
+          ? s.retrospective as Record<string, string>
+          : (s.retrospective as string) ?? "",
+        mentorComment: s.mentorComment,
+        photos: s.photos,
+        certificateMessage: s.certificateMessage,
+        ...(s.interests.length > 0 && { interests: s.interests }),
+        ...(s.achievements && { achievements: s.achievements }),
+        ...(s.portfolioLinks != null && typeof s.portfolioLinks === "object"
+          ? { portfolioLinks: s.portfolioLinks as Record<string, string> }
+          : {}),
+        ...(s.thanksMessage && { thanksMessage: s.thanksMessage }),
+      };
+    })
+  );
+
+  return {
+    id: cohortRow.id,
+    name: cohortRow.name,
+    program: cohortRow.program,
+    graduationDate: formatDate(cohortRow.graduationDate),
+    summary: cohortRow.summary,
+    tagline: cohortRow.tagline,
+    students: studentsWithProjects,
+    ...(cohortRow.operatorMessage && { operatorMessage: cohortRow.operatorMessage }),
+    ...(cohortRow.philosophy && { philosophy: cohortRow.philosophy }),
+    ...(cohortRow.photos.length > 0 && { photos: cohortRow.photos }),
+  };
 }
 
 // 진행 중인 책 생성 요청을 추적 (중복 요청 차단)
@@ -228,6 +309,7 @@ app.get("/api/students/:id", async (request: Request, response: Response) => {
     response.json({
       student: {
         id: student.id,
+        cohortId: student.cohortId,
         name: student.name,
         roleTrack: student.roleTrack,
         bio: student.bio,
@@ -457,7 +539,51 @@ app.delete("/api/projects/:id", async (request: Request, response: Response) => 
   }
 });
 
-// --- Books / Orders ---
+// --- Books / Orders / Preview ---
+
+/**
+ * 책 프리뷰 페이로드 생성 (#88).
+ *
+ * payload-mapper의 buildCoverPayload + buildContentsPayload 결과를
+ * 그대로 JSON으로 반환한다. 프론트엔드 BookPreview가 이 데이터를
+ * PageRenderer로 렌더링한다.
+ *
+ * 부수효과 없는 조회이므로 Idempotency-Key 불필요.
+ */
+app.post("/api/preview-payload", async (request: Request, response: Response) => {
+  const { session, cohortId, studentId } = request.body as {
+    session?: EditSessionInput;
+    cohortId?: string;
+    studentId?: string;
+  };
+
+  if (!session || !cohortId) {
+    response.status(400).json({ message: "session과 cohortId가 필요합니다." });
+    return;
+  }
+
+  const cohort = await loadCohortFromDb(cohortId);
+  if (!cohort) {
+    response.status(404).json({ message: "기수를 찾을 수 없습니다." });
+    return;
+  }
+
+  const student: StudentPortfolio | undefined = studentId
+    ? cohort.students.find((s) => s.id === studentId)
+    : undefined;
+
+  try {
+    const cover = buildCoverPayload(session, cohort, student);
+    const contents = buildContentsPayload(session, cohort, student);
+    response.json({ cover, contents });
+  } catch (error) {
+    logger.error(
+      { err: error instanceof Error ? error.message : String(error) },
+      "preview-payload 생성 실패"
+    );
+    response.status(500).json({ message: "프리뷰 페이로드 생성에 실패했습니다." });
+  }
+});
 
 app.post("/api/books", async (request: Request, response: Response) => {
   const idempotencyKey = request.headers["idempotency-key"];
@@ -484,68 +610,13 @@ app.post("/api/books", async (request: Request, response: Response) => {
 
   const { SWEETBOOK_API_BASE_URL, SWEETBOOK_API_KEY } = getEnv();
   const client = createSweetBookClient(SWEETBOOK_API_BASE_URL, SWEETBOOK_API_KEY);
-  const db = getPrisma();
 
-  // DB에서 cohort + students + projects 조회하여 Cohort[] 형태로 변환
-  const cohortRow = await db.cohort.findUnique({ where: { id: cohortId } });
-  if (!cohortRow) {
+  const cohort = await loadCohortFromDb(cohortId);
+  if (!cohort) {
     response.status(404).json({ message: "기수를 찾을 수 없습니다." });
     return;
   }
-  const studentRows = await db.student.findMany({ where: { cohortId }, orderBy: { createdAt: "asc" } });
-  const studentsWithProjects = await Promise.all(
-    studentRows.map(async (s: {
-      id: string; name: string; roleTrack: string; bio: string;
-      techStack: string[]; mentorComment: string; photos: string[];
-      certificateMessage: string; retrospective: unknown;
-      interests: string[]; achievements: string | null;
-      portfolioLinks: unknown; thanksMessage: string | null;
-    }) => {
-      const projects = await db.project.findMany({ where: { studentId: s.id }, orderBy: { createdAt: "asc" } });
-      return {
-        id: s.id,
-        name: s.name,
-        roleTrack: s.roleTrack,
-        bio: s.bio,
-        techStack: s.techStack,
-        projects: projects.map((p: {
-          title: string; summary: string; contribution: string; links: string[];
-          problem: string | null; solution: string | null; techChoices: string[]; result: string | null;
-        }) => ({
-          title: p.title,
-          summary: p.summary,
-          contribution: p.contribution,
-          links: p.links,
-          ...(p.problem && { problem: p.problem }),
-          ...(p.solution && { solution: p.solution }),
-          ...(p.techChoices.length > 0 && { techChoices: p.techChoices }),
-          ...(p.result && { result: p.result }),
-        })),
-        retrospective: typeof s.retrospective === "object" && s.retrospective !== null
-          ? s.retrospective as Record<string, string>
-          : (s.retrospective as string) ?? "",
-        mentorComment: s.mentorComment,
-        photos: s.photos,
-        certificateMessage: s.certificateMessage,
-        ...(s.interests.length > 0 && { interests: s.interests }),
-        ...(s.achievements && { achievements: s.achievements }),
-        ...(s.portfolioLinks != null && typeof s.portfolioLinks === "object" ? { portfolioLinks: s.portfolioLinks as Record<string, string> } : {}),
-        ...(s.thanksMessage && { thanksMessage: s.thanksMessage }),
-      };
-    })
-  );
-  const cohortsData = [{
-    id: cohortRow.id,
-    name: cohortRow.name,
-    program: cohortRow.program,
-    graduationDate: formatDate(cohortRow.graduationDate),
-    summary: cohortRow.summary,
-    tagline: cohortRow.tagline,
-    students: studentsWithProjects,
-    ...(cohortRow.operatorMessage && { operatorMessage: cohortRow.operatorMessage }),
-    ...(cohortRow.philosophy && { philosophy: cohortRow.philosophy }),
-    ...(cohortRow.photos.length > 0 && { photos: cohortRow.photos }),
-  }];
+  const cohortsData = [cohort];
 
   inProgressKeys.add(idempotencyKey);
   try {

--- a/apps/web/src/app/cohorts/[cohortId]/create/CohortEditForm.tsx
+++ b/apps/web/src/app/cohorts/[cohortId]/create/CohortEditForm.tsx
@@ -14,11 +14,13 @@ import {
 } from "@/lib/edit-session";
 import type { EditSession } from "@/lib/edit-session";
 import PageBlockList from "@/components/PageBlockList";
+import BookPreview from "@/components/preview/BookPreview";
 
 type BookCreateStatus = "idle" | "loading" | "success" | "error";
 type OrderStatus = "idle" | "loading" | "success" | "error";
 
 const TEXT = {
+  preview: "프리뷰 보기",
   complete: "편집 완료",
   loading: "책 생성 중...",
   retry: "다시 시도",
@@ -71,6 +73,7 @@ export default function CohortEditForm({
   const [orderStatus, setOrderStatus] = useState<OrderStatus>("idle");
   const [orderUid, setOrderUid] = useState<string | null>(null);
   const [orderErrorMessage, setOrderErrorMessage] = useState<string | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const bookTypeInfo = BOOK_TYPE_LABELS[bookType];
 
@@ -163,7 +166,22 @@ export default function CohortEditForm({
           onToggle={handleToggleBlock}
           onMove={handleMovePage}
         />
+
+        <button
+          type="button"
+          onClick={() => setPreviewOpen(true)}
+          className="inline-flex w-full items-center justify-center rounded-xl border border-[color:var(--accent)]/30 bg-[color:var(--surface)] px-6 py-2.5 text-sm font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)]"
+        >
+          {TEXT.preview}
+        </button>
       </div>
+
+      <BookPreview
+        isOpen={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        session={session}
+        cohortId={cohortId}
+      />
 
       {bookStatus === "success" && bookUid ? (
         <div className="mt-6 space-y-3">

--- a/apps/web/src/app/cohorts/[cohortId]/page.tsx
+++ b/apps/web/src/app/cohorts/[cohortId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { BackLink } from "@/components/BackLink";
 import { EmptyState } from "@/components/EmptyState";
+import StudentAdminPanel from "@/components/admin/StudentAdminPanel";
 import { getCohort } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
@@ -112,6 +113,10 @@ export default async function CohortDetailPage({ params }: CohortDetailPageProps
             </div>
           </Link>
         ))}
+      </section>
+
+      <section className="mt-10">
+        <StudentAdminPanel cohortId={cohort.id} students={cohort.students} />
       </section>
     </main>
   );

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { EmptyState } from "@/components/EmptyState";
+import CohortAdminPanel from "@/components/admin/CohortAdminPanel";
 import { getCohorts } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
@@ -90,6 +91,10 @@ export default async function DashboardPage() {
             </div>
           </Link>
         ))}
+      </section>
+
+      <section className="mt-14">
+        <CohortAdminPanel cohorts={cohorts} />
       </section>
     </main>
   );

--- a/apps/web/src/app/students/[studentId]/create/EditForm.tsx
+++ b/apps/web/src/app/students/[studentId]/create/EditForm.tsx
@@ -14,11 +14,13 @@ import {
 } from "@/lib/edit-session";
 import type { EditSession } from "@/lib/edit-session";
 import PageBlockList from "@/components/PageBlockList";
+import BookPreview from "@/components/preview/BookPreview";
 
 type BookCreateStatus = "idle" | "loading" | "success" | "error";
 type OrderStatus = "idle" | "loading" | "success" | "error";
 
 const TEXT = {
+  preview: "프리뷰 보기",
   complete: "편집 완료",
   loading: "책 생성 중...",
   retry: "다시 시도",
@@ -60,6 +62,7 @@ export default function EditForm({ bookType, studentName, cohortId, studentId, p
   const [orderStatus, setOrderStatus] = useState<OrderStatus>("idle");
   const [orderUid, setOrderUid] = useState<string | null>(null);
   const [orderErrorMessage, setOrderErrorMessage] = useState<string | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const bookTypeInfo = BOOK_TYPE_LABELS[bookType];
 
@@ -169,7 +172,23 @@ export default function EditForm({ bookType, studentName, cohortId, studentId, p
           onToggle={handleToggleBlock}
           onMove={handleMovePage}
         />
+
+        <button
+          type="button"
+          onClick={() => setPreviewOpen(true)}
+          className="inline-flex w-full items-center justify-center rounded-xl border border-[color:var(--accent)]/30 bg-[color:var(--surface)] px-6 py-2.5 text-sm font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)]"
+        >
+          {TEXT.preview}
+        </button>
       </div>
+
+      <BookPreview
+        isOpen={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        session={session}
+        cohortId={cohortId}
+        studentId={studentId}
+      />
 
       {bookStatus === "success" && bookUid ? (
         <div className="mt-6 space-y-3">

--- a/apps/web/src/app/students/[studentId]/page.tsx
+++ b/apps/web/src/app/students/[studentId]/page.tsx
@@ -2,9 +2,30 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { BackLink } from "@/components/BackLink";
+import ProjectAdminPanel from "@/components/admin/ProjectAdminPanel";
+import StudentEditDeletePanel from "@/components/admin/StudentEditDeletePanel";
 import { getStudent } from "@/lib/api";
+import type { ProjectRecord, RetrospectiveData } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * 회고 데이터를 표시용 텍스트로 변환한다.
+ * 백엔드는 string(레거시) 또는 6필드 객체(#82 이후)로 반환한다.
+ */
+function formatRetrospective(retro: string | RetrospectiveData): string {
+  if (typeof retro === "string") return retro;
+
+  const sections: string[] = [];
+  if (retro.before) sections.push(retro.before);
+  if (retro.process) sections.push(retro.process);
+  if (retro.turning) sections.push(retro.turning);
+  if (retro.difficulty) sections.push(retro.difficulty);
+  if (retro.overcome) sections.push(retro.overcome);
+  if (retro.learned) sections.push(retro.learned);
+
+  return sections.join(" ");
+}
 
 interface StudentDetailPageProps {
   params: Promise<{ studentId: string }>;
@@ -23,7 +44,12 @@ export default async function StudentDetailPage({ params }: StudentDetailPagePro
       <BackLink href="/dashboard">대시보드로 돌아가기</BackLink>
 
       <section className="mt-5 animate-fade-up overflow-hidden rounded-2xl border border-[color:var(--border-soft)] bg-[color:var(--surface)] px-6 py-10 shadow-[0_2px_16px_var(--shadow-tint)] sm:px-8">
-        <p className="text-xs font-semibold tracking-[0.25em] text-[color:var(--accent)] uppercase">{student.roleTrack}</p>
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-xs font-semibold tracking-[0.25em] text-[color:var(--accent)] uppercase">{student.roleTrack}</p>
+          {student.cohortId && (
+            <StudentEditDeletePanel student={student} cohortId={student.cohortId} />
+          )}
+        </div>
         <div className="mt-5 grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-end">
           <div>
             <h1 className="font-display text-3xl font-bold leading-tight tracking-tight text-[color:var(--foreground)] md:text-5xl">{student.name}</h1>
@@ -79,7 +105,7 @@ export default async function StudentDetailPage({ params }: StudentDetailPagePro
           <article className="animate-fade-up delay-3 rounded-2xl rounded-l-none border-l-2 border-[color:var(--accent)] bg-[color:var(--surface)] px-6 py-6 shadow-[0_2px_16px_var(--shadow-tint)]">
             <p className="text-[10px] font-semibold tracking-[0.2em] text-[color:var(--accent)] uppercase">회고</p>
             <p className="font-display mt-4 text-lg font-medium leading-8 text-[color:var(--text-default)]">
-              &ldquo;{student.retrospective}&rdquo;
+              &ldquo;{formatRetrospective(student.retrospective)}&rdquo;
             </p>
           </article>
 
@@ -118,6 +144,17 @@ export default async function StudentDetailPage({ params }: StudentDetailPagePro
             책 종류 선택하기 <span>&rarr;</span>
           </Link>
         </aside>
+      </section>
+
+      <section className="mt-10">
+        <ProjectAdminPanel
+          studentId={student.id}
+          projects={
+            student.projects.filter(
+              (p): p is ProjectRecord => typeof p.id === "string"
+            ) as ProjectRecord[]
+          }
+        />
       </section>
     </main>
   );

--- a/apps/web/src/components/admin/CohortAdminPanel.tsx
+++ b/apps/web/src/components/admin/CohortAdminPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteCohort } from "@/lib/api";
+import type { CohortSummary } from "@/lib/api";
+
+import CohortFormDialog, { type CohortFormInitial } from "./CohortFormDialog";
+import ConfirmDeleteDialog from "./ConfirmDeleteDialog";
+
+interface CohortAdminPanelProps {
+  cohorts: CohortSummary[];
+}
+
+const TEXT = {
+  add: "기수 추가",
+  edit: "수정",
+  delete: "삭제",
+  deleteTitle: "기수 삭제",
+  deleteMessage: (name: string) =>
+    `'${name}' 기수와 소속된 모든 수료생·프로젝트가 삭제됩니다. 되돌릴 수 없습니다.`,
+} as const;
+
+export default function CohortAdminPanel({ cohorts }: CohortAdminPanelProps) {
+  const router = useRouter();
+  const [formOpen, setFormOpen] = useState(false);
+  const [formInitial, setFormInitial] = useState<CohortFormInitial | undefined>();
+  const [deleteTarget, setDeleteTarget] = useState<CohortSummary | null>(null);
+
+  function openCreate() {
+    setFormInitial(undefined);
+    setFormOpen(true);
+  }
+
+  function openEdit(c: CohortSummary) {
+    setFormInitial({
+      id: c.id,
+      name: c.name,
+      program: c.program,
+      graduationDate: c.graduationDate,
+      summary: c.summary,
+      tagline: c.tagline,
+    });
+    setFormOpen(true);
+  }
+
+  return (
+    <div className="rounded-2xl border border-[color:var(--border-soft)] bg-[color:var(--surface)] p-6">
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-lg font-bold text-[color:var(--foreground)]">
+          기수 관리
+        </h2>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white"
+        >
+          + {TEXT.add}
+        </button>
+      </div>
+
+      {cohorts.length === 0 ? (
+        <p className="mt-4 text-sm text-[color:var(--text-dim)]">
+          등록된 기수가 없습니다. 위 버튼으로 추가하세요.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {cohorts.map((c) => (
+            <li
+              key={c.id}
+              className="flex items-center justify-between rounded-lg border border-[color:var(--border-soft)] bg-[color:var(--surface-elevated)] px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-semibold text-[color:var(--foreground)]">
+                  {c.name}
+                </p>
+                <p className="truncate text-xs text-[color:var(--text-dim)]">
+                  {c.program} · {c.graduationDate}
+                </p>
+              </div>
+              <div className="flex shrink-0 gap-1">
+                <button
+                  type="button"
+                  onClick={() => openEdit(c)}
+                  className="rounded px-2 py-1 text-xs font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)]"
+                >
+                  {TEXT.edit}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setDeleteTarget(c)}
+                  className="rounded px-2 py-1 text-xs font-semibold text-[color:var(--error)] hover:bg-[color:var(--error-soft)]"
+                >
+                  {TEXT.delete}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <CohortFormDialog
+        isOpen={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSuccess={() => router.refresh()}
+        initial={formInitial}
+      />
+
+      <ConfirmDeleteDialog
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={async () => {
+          if (deleteTarget) {
+            await deleteCohort(deleteTarget.id);
+            router.refresh();
+          }
+        }}
+        title={TEXT.deleteTitle}
+        message={deleteTarget ? TEXT.deleteMessage(deleteTarget.name) : ""}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/CohortFormDialog.tsx
+++ b/apps/web/src/components/admin/CohortFormDialog.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+
+import { createCohort, updateCohort, type CohortInput } from "@/lib/api";
+
+import Modal from "./Modal";
+import { TextAreaField, TextField } from "./form-fields";
+
+export interface CohortFormInitial extends CohortInput {
+  id?: string;
+}
+
+interface CohortFormDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  initial?: CohortFormInitial;
+}
+
+const EMPTY: CohortFormInitial = {
+  name: "",
+  program: "",
+  graduationDate: "",
+  summary: "",
+  tagline: "",
+};
+
+export default function CohortFormDialog({
+  isOpen,
+  onClose,
+  onSuccess,
+  initial,
+}: CohortFormDialogProps) {
+  const [form, setForm] = useState<CohortFormInitial>(initial ?? EMPTY);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = Boolean(initial?.id);
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm(initial ?? EMPTY);
+      setError(null);
+    }
+  }, [isOpen, initial]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (isEdit && initial?.id) {
+        await updateCohort(initial.id, form);
+      } else {
+        await createCohort(form);
+      }
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "저장에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={isEdit ? "기수 수정" : "기수 추가"}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          id="cohort-name"
+          label="기수 이름"
+          value={form.name}
+          onChange={(v) => setForm((f) => ({ ...f, name: v }))}
+          required
+          placeholder="예: 웹 풀스택 6기"
+        />
+        <TextField
+          id="cohort-program"
+          label="과정명"
+          value={form.program}
+          onChange={(v) => setForm((f) => ({ ...f, program: v }))}
+          required
+          placeholder="예: SweetBootcamp Web Fullstack"
+        />
+        <TextField
+          id="cohort-graduationDate"
+          label="수료일"
+          type="date"
+          value={form.graduationDate}
+          onChange={(v) => setForm((f) => ({ ...f, graduationDate: v }))}
+          required
+        />
+        <TextAreaField
+          id="cohort-summary"
+          label="요약"
+          value={form.summary}
+          onChange={(v) => setForm((f) => ({ ...f, summary: v }))}
+          required
+          rows={3}
+        />
+        <TextField
+          id="cohort-tagline"
+          label="태그라인"
+          value={form.tagline}
+          onChange={(v) => setForm((f) => ({ ...f, tagline: v }))}
+          required
+        />
+
+        {error && <p className="text-sm text-[color:var(--error)]">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-lg px-4 py-2 text-sm text-[color:var(--text-muted)] hover:bg-[color:var(--surface-elevated)] disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? "저장 중..." : isEdit ? "수정" : "추가"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/admin/ConfirmDeleteDialog.tsx
+++ b/apps/web/src/components/admin/ConfirmDeleteDialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import Modal from "./Modal";
+
+interface ConfirmDeleteDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  title: string;
+  message: string;
+}
+
+export default function ConfirmDeleteDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+}: ConfirmDeleteDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleConfirm() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "삭제에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <p className="text-sm leading-7 text-[color:var(--text-default)]">{message}</p>
+      {error && <p className="mt-3 text-sm text-[color:var(--error)]">{error}</p>}
+      <div className="mt-6 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={submitting}
+          className="rounded-lg px-4 py-2 text-sm text-[color:var(--text-muted)] hover:bg-[color:var(--surface-elevated)] disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={submitting}
+          className="rounded-lg bg-[color:var(--error)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          {submitting ? "삭제 중..." : "삭제"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/admin/Modal.tsx
+++ b/apps/web/src/components/admin/Modal.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+export default function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex max-h-[90vh] w-full max-w-xl flex-col rounded-2xl bg-[color:var(--surface)] shadow-2xl">
+        <div className="flex items-center justify-between border-b border-[color:var(--border-soft)] px-6 py-4">
+          <h2 className="font-display text-xl font-bold text-[color:var(--foreground)]">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="닫기"
+            className="rounded-lg px-3 py-1.5 text-sm text-[color:var(--text-muted)] hover:bg-[color:var(--surface-elevated)]"
+          >
+            닫기
+          </button>
+        </div>
+        <div className="flex-1 overflow-auto px-6 py-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/ProjectAdminPanel.tsx
+++ b/apps/web/src/components/admin/ProjectAdminPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteProject } from "@/lib/api";
+import type { ProjectRecord } from "@/lib/api";
+
+import ConfirmDeleteDialog from "./ConfirmDeleteDialog";
+import ProjectFormDialog, { type ProjectFormInitial } from "./ProjectFormDialog";
+
+interface ProjectAdminPanelProps {
+  studentId: string;
+  projects: ProjectRecord[];
+}
+
+const TEXT = {
+  add: "프로젝트 추가",
+  edit: "수정",
+  delete: "삭제",
+  deleteTitle: "프로젝트 삭제",
+  deleteMessage: (title: string) => `'${title}' 프로젝트가 삭제됩니다. 되돌릴 수 없습니다.`,
+} as const;
+
+export default function ProjectAdminPanel({ studentId, projects }: ProjectAdminPanelProps) {
+  const router = useRouter();
+  const [formOpen, setFormOpen] = useState(false);
+  const [formInitial, setFormInitial] = useState<ProjectFormInitial | undefined>();
+  const [deleteTarget, setDeleteTarget] = useState<ProjectRecord | null>(null);
+
+  function openCreate() {
+    setFormInitial(undefined);
+    setFormOpen(true);
+  }
+
+  function openEdit(p: ProjectRecord) {
+    setFormInitial({
+      id: p.id,
+      title: p.title,
+      summary: p.summary,
+      contribution: p.contribution,
+      links: p.links,
+    });
+    setFormOpen(true);
+  }
+
+  return (
+    <div className="rounded-2xl border border-[color:var(--border-soft)] bg-[color:var(--surface)] p-6">
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-lg font-bold text-[color:var(--foreground)]">
+          프로젝트 관리
+        </h2>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white"
+        >
+          + {TEXT.add}
+        </button>
+      </div>
+
+      {projects.length === 0 ? (
+        <p className="mt-4 text-sm text-[color:var(--text-dim)]">
+          등록된 프로젝트가 없습니다.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {projects.map((p) => (
+            <li
+              key={p.id}
+              className="flex items-center justify-between rounded-lg border border-[color:var(--border-soft)] bg-[color:var(--surface-elevated)] px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-semibold text-[color:var(--foreground)]">
+                  {p.title}
+                </p>
+                <p className="truncate text-xs text-[color:var(--text-dim)]">
+                  {p.summary}
+                </p>
+              </div>
+              <div className="flex shrink-0 gap-1">
+                <button
+                  type="button"
+                  onClick={() => openEdit(p)}
+                  className="rounded px-2 py-1 text-xs font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)]"
+                >
+                  {TEXT.edit}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setDeleteTarget(p)}
+                  className="rounded px-2 py-1 text-xs font-semibold text-[color:var(--error)] hover:bg-[color:var(--error-soft)]"
+                >
+                  {TEXT.delete}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ProjectFormDialog
+        isOpen={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSuccess={() => router.refresh()}
+        studentId={studentId}
+        initial={formInitial}
+      />
+
+      <ConfirmDeleteDialog
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={async () => {
+          if (deleteTarget) {
+            await deleteProject(deleteTarget.id);
+            router.refresh();
+          }
+        }}
+        title={TEXT.deleteTitle}
+        message={deleteTarget ? TEXT.deleteMessage(deleteTarget.title) : ""}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/ProjectFormDialog.tsx
+++ b/apps/web/src/components/admin/ProjectFormDialog.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+
+import { createProject, updateProject, type ProjectInput } from "@/lib/api";
+
+import Modal from "./Modal";
+import { CommaListField, TextAreaField, TextField } from "./form-fields";
+
+export interface ProjectFormInitial extends ProjectInput {
+  id?: string;
+}
+
+interface ProjectFormDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  studentId: string;
+  initial?: ProjectFormInitial;
+}
+
+const EMPTY: ProjectFormInitial = {
+  title: "",
+  summary: "",
+  contribution: "",
+  links: [],
+};
+
+export default function ProjectFormDialog({
+  isOpen,
+  onClose,
+  onSuccess,
+  studentId,
+  initial,
+}: ProjectFormDialogProps) {
+  const [form, setForm] = useState<ProjectFormInitial>(initial ?? EMPTY);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = Boolean(initial?.id);
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm(initial ?? EMPTY);
+      setError(null);
+    }
+  }, [isOpen, initial]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (isEdit && initial?.id) {
+        await updateProject(initial.id, form);
+      } else {
+        await createProject(studentId, form);
+      }
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "저장에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={isEdit ? "프로젝트 수정" : "프로젝트 추가"}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          id="project-title"
+          label="제목"
+          value={form.title}
+          onChange={(v) => setForm((f) => ({ ...f, title: v }))}
+          required
+        />
+        <TextAreaField
+          id="project-summary"
+          label="요약"
+          value={form.summary}
+          onChange={(v) => setForm((f) => ({ ...f, summary: v }))}
+          required
+          rows={2}
+        />
+        <TextAreaField
+          id="project-contribution"
+          label="기여"
+          value={form.contribution}
+          onChange={(v) => setForm((f) => ({ ...f, contribution: v }))}
+          required
+          rows={3}
+        />
+        <CommaListField
+          id="project-links"
+          label="링크"
+          value={form.links}
+          onChange={(v) => setForm((f) => ({ ...f, links: v }))}
+          placeholder="https://github.com/..., https://demo.com/..."
+        />
+
+        {error && <p className="text-sm text-[color:var(--error)]">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-lg px-4 py-2 text-sm text-[color:var(--text-muted)] hover:bg-[color:var(--surface-elevated)] disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? "저장 중..." : isEdit ? "수정" : "추가"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/admin/StudentAdminPanel.tsx
+++ b/apps/web/src/components/admin/StudentAdminPanel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteStudent } from "@/lib/api";
+import type { CohortStudentSummary } from "@/lib/api";
+
+import ConfirmDeleteDialog from "./ConfirmDeleteDialog";
+import StudentFormDialog, { type StudentFormInitial } from "./StudentFormDialog";
+
+interface StudentAdminPanelProps {
+  cohortId: string;
+  students: CohortStudentSummary[];
+}
+
+const TEXT = {
+  add: "수료생 추가",
+  delete: "삭제",
+  deleteTitle: "수료생 삭제",
+  deleteMessage: (name: string) =>
+    `'${name}' 수료생과 소속된 모든 프로젝트가 삭제됩니다. 되돌릴 수 없습니다.`,
+} as const;
+
+export default function StudentAdminPanel({ cohortId, students }: StudentAdminPanelProps) {
+  const router = useRouter();
+  const [formOpen, setFormOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<CohortStudentSummary | null>(null);
+
+  // 수료생 수정은 상세 페이지(/students/[id])에서 처리하므로
+  // 여기서는 추가/삭제만 제공.
+  const formInitial: StudentFormInitial | undefined = undefined;
+
+  return (
+    <div className="rounded-2xl border border-[color:var(--border-soft)] bg-[color:var(--surface)] p-6">
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-lg font-bold text-[color:var(--foreground)]">
+          수료생 관리
+        </h2>
+        <button
+          type="button"
+          onClick={() => setFormOpen(true)}
+          className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white"
+        >
+          + {TEXT.add}
+        </button>
+      </div>
+
+      {students.length === 0 ? (
+        <p className="mt-4 text-sm text-[color:var(--text-dim)]">
+          등록된 수료생이 없습니다.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {students.map((s) => (
+            <li
+              key={s.id}
+              className="flex items-center justify-between rounded-lg border border-[color:var(--border-soft)] bg-[color:var(--surface-elevated)] px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-semibold text-[color:var(--foreground)]">
+                  {s.name}
+                </p>
+                <p className="truncate text-xs text-[color:var(--text-dim)]">
+                  {s.roleTrack} · 프로젝트 {s.projectCount}개
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(s)}
+                className="ml-2 shrink-0 rounded px-2 py-1 text-xs font-semibold text-[color:var(--error)] hover:bg-[color:var(--error-soft)]"
+              >
+                {TEXT.delete}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <StudentFormDialog
+        isOpen={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSuccess={() => router.refresh()}
+        cohortId={cohortId}
+        initial={formInitial}
+      />
+
+      <ConfirmDeleteDialog
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={async () => {
+          if (deleteTarget) {
+            await deleteStudent(deleteTarget.id);
+            router.refresh();
+          }
+        }}
+        title={TEXT.deleteTitle}
+        message={deleteTarget ? TEXT.deleteMessage(deleteTarget.name) : ""}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/StudentEditDeletePanel.tsx
+++ b/apps/web/src/components/admin/StudentEditDeletePanel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteStudent } from "@/lib/api";
+import type { StudentPortfolio } from "@/lib/api";
+
+import ConfirmDeleteDialog from "./ConfirmDeleteDialog";
+import StudentFormDialog, { type StudentFormInitial } from "./StudentFormDialog";
+
+interface StudentEditDeletePanelProps {
+  student: StudentPortfolio;
+  cohortId: string;
+}
+
+/**
+ * 수료생 상세 페이지에 표시되는 수정/삭제 액션 패널.
+ * 삭제 후 cohort 페이지로 이동.
+ */
+export default function StudentEditDeletePanel({
+  student,
+  cohortId,
+}: StudentEditDeletePanelProps) {
+  const router = useRouter();
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const initial: StudentFormInitial = {
+    id: student.id,
+    name: student.name,
+    roleTrack: student.roleTrack,
+    bio: student.bio,
+    techStack: student.techStack,
+    mentorComment: student.mentorComment,
+    photos: student.photos,
+    certificateMessage: student.certificateMessage,
+  };
+
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        onClick={() => setEditOpen(true)}
+        className="rounded-lg border border-[color:var(--accent)]/30 bg-[color:var(--surface)] px-3 py-1.5 text-xs font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)]"
+      >
+        수정
+      </button>
+      <button
+        type="button"
+        onClick={() => setDeleteOpen(true)}
+        className="rounded-lg border border-[color:var(--error)]/30 bg-[color:var(--surface)] px-3 py-1.5 text-xs font-semibold text-[color:var(--error)] hover:bg-[color:var(--error-soft)]"
+      >
+        삭제
+      </button>
+
+      <StudentFormDialog
+        isOpen={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSuccess={() => router.refresh()}
+        cohortId={cohortId}
+        initial={initial}
+      />
+
+      <ConfirmDeleteDialog
+        isOpen={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={async () => {
+          await deleteStudent(student.id);
+          router.push(`/cohorts/${cohortId}`);
+        }}
+        title="수료생 삭제"
+        message={`'${student.name}' 수료생과 소속 프로젝트가 모두 삭제됩니다. 되돌릴 수 없습니다.`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/StudentFormDialog.tsx
+++ b/apps/web/src/components/admin/StudentFormDialog.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+
+import { createStudent, updateStudent, type StudentInput } from "@/lib/api";
+
+import Modal from "./Modal";
+import { CommaListField, TextAreaField, TextField } from "./form-fields";
+
+export interface StudentFormInitial extends StudentInput {
+  id?: string;
+}
+
+interface StudentFormDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  cohortId: string;
+  initial?: StudentFormInitial;
+}
+
+const EMPTY: StudentFormInitial = {
+  name: "",
+  roleTrack: "",
+  bio: "",
+  techStack: [],
+  mentorComment: "",
+  photos: [],
+  certificateMessage: "",
+};
+
+export default function StudentFormDialog({
+  isOpen,
+  onClose,
+  onSuccess,
+  cohortId,
+  initial,
+}: StudentFormDialogProps) {
+  const [form, setForm] = useState<StudentFormInitial>(initial ?? EMPTY);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = Boolean(initial?.id);
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm(initial ?? EMPTY);
+      setError(null);
+    }
+  }, [isOpen, initial]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (isEdit && initial?.id) {
+        await updateStudent(initial.id, form);
+      } else {
+        await createStudent(cohortId, form);
+      }
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "저장에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={isEdit ? "수료생 수정" : "수료생 추가"}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          id="student-name"
+          label="이름"
+          value={form.name}
+          onChange={(v) => setForm((f) => ({ ...f, name: v }))}
+          required
+        />
+        <TextField
+          id="student-roleTrack"
+          label="역할/트랙"
+          value={form.roleTrack}
+          onChange={(v) => setForm((f) => ({ ...f, roleTrack: v }))}
+          required
+          placeholder="예: 풀스택"
+        />
+        <TextAreaField
+          id="student-bio"
+          label="자기소개"
+          value={form.bio}
+          onChange={(v) => setForm((f) => ({ ...f, bio: v }))}
+          required
+          rows={3}
+        />
+        <CommaListField
+          id="student-techStack"
+          label="기술 스택"
+          value={form.techStack}
+          onChange={(v) => setForm((f) => ({ ...f, techStack: v }))}
+          placeholder="예: TypeScript, Next.js, Prisma"
+        />
+        <TextAreaField
+          id="student-mentorComment"
+          label="멘토 코멘트"
+          value={form.mentorComment}
+          onChange={(v) => setForm((f) => ({ ...f, mentorComment: v }))}
+          required
+          rows={3}
+        />
+        <CommaListField
+          id="student-photos"
+          label="사진 URL"
+          value={form.photos}
+          onChange={(v) => setForm((f) => ({ ...f, photos: v }))}
+          placeholder="https://..., https://..."
+        />
+        <TextAreaField
+          id="student-certificateMessage"
+          label="수료 메시지"
+          value={form.certificateMessage}
+          onChange={(v) => setForm((f) => ({ ...f, certificateMessage: v }))}
+          required
+          rows={2}
+        />
+
+        {error && <p className="text-sm text-[color:var(--error)]">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-lg px-4 py-2 text-sm text-[color:var(--text-muted)] hover:bg-[color:var(--surface-elevated)] disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? "저장 중..." : isEdit ? "수정" : "추가"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/admin/__tests__/CohortFormDialog.test.tsx
+++ b/apps/web/src/components/admin/__tests__/CohortFormDialog.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import CohortFormDialog from "../CohortFormDialog";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockOk(body: object) {
+  vi.mocked(fetch).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const VALID_COHORT = {
+  id: "c1",
+  name: "기수1",
+  program: "프로그램",
+  graduationDate: "2026-04-30",
+  summary: "요약",
+  tagline: "태그",
+};
+
+describe("CohortFormDialog", () => {
+  it("isOpen=false이면 렌더링하지 않아야 한다", () => {
+    const { container } = render(
+      <CohortFormDialog isOpen={false} onClose={() => {}} onSuccess={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("create 모드 (initial 없음)", () => {
+    it("제목이 '기수 추가'여야 한다", () => {
+      render(
+        <CohortFormDialog isOpen={true} onClose={() => {}} onSuccess={() => {}} />
+      );
+      expect(screen.getByText("기수 추가")).toBeDefined();
+    });
+
+    it("submit 버튼이 '추가'여야 한다", () => {
+      render(
+        <CohortFormDialog isOpen={true} onClose={() => {}} onSuccess={() => {}} />
+      );
+      expect(screen.getByRole("button", { name: "추가" })).toBeDefined();
+    });
+
+    it("submit 시 POST /api/cohorts를 호출해야 한다", async () => {
+      mockOk({ cohort: VALID_COHORT });
+      const onSuccess = vi.fn();
+      const onClose = vi.fn();
+      render(
+        <CohortFormDialog
+          isOpen={true}
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/기수 이름/), { target: { value: "기수1" } });
+      fireEvent.change(screen.getByLabelText(/과정명/), { target: { value: "프로그램" } });
+      fireEvent.change(screen.getByLabelText(/수료일/), { target: { value: "2026-04-30" } });
+      fireEvent.change(screen.getByLabelText(/요약/), { target: { value: "요약" } });
+      fireEvent.change(screen.getByLabelText(/태그라인/), { target: { value: "태그" } });
+
+      fireEvent.click(screen.getByRole("button", { name: "추가" }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalled();
+      });
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(String(call[0])).toContain("/api/cohorts");
+      expect(String(call[0])).not.toContain("/api/cohorts/c1");
+      expect(call[1]?.method).toBe("POST");
+    });
+  });
+
+  describe("edit 모드 (initial.id 있음)", () => {
+    const initial = { ...VALID_COHORT };
+
+    it("제목이 '기수 수정'이어야 한다", () => {
+      render(
+        <CohortFormDialog
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          initial={initial}
+        />
+      );
+      expect(screen.getByText("기수 수정")).toBeDefined();
+    });
+
+    it("submit 버튼이 '수정'이어야 한다", () => {
+      render(
+        <CohortFormDialog
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          initial={initial}
+        />
+      );
+      expect(screen.getByRole("button", { name: "수정" })).toBeDefined();
+    });
+
+    it("초기 값이 폼에 채워져야 한다", () => {
+      render(
+        <CohortFormDialog
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          initial={initial}
+        />
+      );
+      const nameInput = screen.getByLabelText(/기수 이름/) as HTMLInputElement;
+      expect(nameInput.value).toBe("기수1");
+    });
+
+    it("submit 시 PATCH /api/cohorts/:id를 호출해야 한다", async () => {
+      mockOk({ cohort: VALID_COHORT });
+      render(
+        <CohortFormDialog
+          isOpen={true}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          initial={initial}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "수정" }));
+      await waitFor(() => {
+        const call = vi.mocked(fetch).mock.calls[0];
+        expect(String(call[0])).toContain("/api/cohorts/c1");
+        expect(call[1]?.method).toBe("PATCH");
+      });
+    });
+  });
+
+  describe("에러 처리", () => {
+    it("API 실패 시 에러 메시지가 표시되고 모달이 유지되어야 한다", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ message: "이름이 필요합니다" }),
+      } as Response);
+      const onClose = vi.fn();
+      const onSuccess = vi.fn();
+      render(
+        <CohortFormDialog
+          isOpen={true}
+          onClose={onClose}
+          onSuccess={onSuccess}
+          initial={VALID_COHORT}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "수정" }));
+      await waitFor(() => {
+        expect(screen.getByText("이름이 필요합니다")).toBeDefined();
+      });
+      expect(onClose).not.toHaveBeenCalled();
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/admin/__tests__/ConfirmDeleteDialog.test.tsx
+++ b/apps/web/src/components/admin/__tests__/ConfirmDeleteDialog.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ConfirmDeleteDialog from "../ConfirmDeleteDialog";
+
+describe("ConfirmDeleteDialog", () => {
+  it("isOpen이 false이면 아무것도 렌더링하지 않아야 한다", () => {
+    const { container } = render(
+      <ConfirmDeleteDialog
+        isOpen={false}
+        onClose={() => {}}
+        onConfirm={async () => {}}
+        title="삭제"
+        message="정말 삭제하시겠습니까?"
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("title과 message를 표시해야 한다", () => {
+    render(
+      <ConfirmDeleteDialog
+        isOpen={true}
+        onClose={() => {}}
+        onConfirm={async () => {}}
+        title="기수 삭제"
+        message="이 기수가 영구 삭제됩니다."
+      />
+    );
+    expect(screen.getByText("기수 삭제")).toBeDefined();
+    expect(screen.getByText("이 기수가 영구 삭제됩니다.")).toBeDefined();
+  });
+
+  it("삭제 버튼 클릭 성공 시 onClose가 호출되어야 한다", async () => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ConfirmDeleteDialog
+        isOpen={true}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        title="삭제"
+        message="msg"
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("API 실패 시 모달이 닫히지 않고 에러 메시지가 표시되어야 한다", async () => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn().mockRejectedValue(new Error("권한이 없습니다"));
+    render(
+      <ConfirmDeleteDialog
+        isOpen={true}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        title="삭제"
+        message="msg"
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    await waitFor(() => {
+      expect(screen.getByText("권한이 없습니다")).toBeDefined();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("취소 버튼 클릭 시 onClose가 호출되고 onConfirm은 호출되지 않아야 한다", () => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDeleteDialog
+        isOpen={true}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        title="삭제"
+        message="msg"
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+    expect(onClose).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("submitting 중에는 삭제 버튼이 '삭제 중...' 텍스트로 변경되어야 한다", async () => {
+    let resolveConfirm: () => void = () => {};
+    const onConfirm = vi.fn(
+      () => new Promise<void>((res) => { resolveConfirm = res; })
+    );
+    render(
+      <ConfirmDeleteDialog
+        isOpen={true}
+        onClose={() => {}}
+        onConfirm={onConfirm}
+        title="삭제"
+        message="msg"
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+    await waitFor(() => {
+      expect(screen.getByText("삭제 중...")).toBeDefined();
+    });
+    resolveConfirm();
+  });
+});

--- a/apps/web/src/components/admin/__tests__/form-fields.test.tsx
+++ b/apps/web/src/components/admin/__tests__/form-fields.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CommaListField, TextAreaField, TextField } from "../form-fields";
+
+describe("CommaListField", () => {
+  it("정상 콤마 분리되어야 한다", () => {
+    const onChange = vi.fn();
+    render(
+      <CommaListField id="test" label="기술" value={[]} onChange={onChange} />
+    );
+    const input = screen.getByLabelText(/기술/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "TypeScript, Next.js, Prisma" } });
+    expect(onChange).toHaveBeenCalledWith(["TypeScript", "Next.js", "Prisma"]);
+  });
+
+  it("각 항목 앞뒤 공백을 trim해야 한다", () => {
+    const onChange = vi.fn();
+    render(
+      <CommaListField id="test" label="기술" value={[]} onChange={onChange} />
+    );
+    const input = screen.getByLabelText(/기술/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  a  ,  b  ,  c  " } });
+    expect(onChange).toHaveBeenCalledWith(["a", "b", "c"]);
+  });
+
+  it("빈 항목(연속 콤마)을 제거해야 한다", () => {
+    const onChange = vi.fn();
+    render(
+      <CommaListField id="test" label="기술" value={[]} onChange={onChange} />
+    );
+    const input = screen.getByLabelText(/기술/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "a,,b,,," } });
+    expect(onChange).toHaveBeenCalledWith(["a", "b"]);
+  });
+
+  it("빈 입력은 빈 배열을 반환해야 한다", () => {
+    const onChange = vi.fn();
+    render(
+      <CommaListField id="test" label="기술" value={["기존"]} onChange={onChange} />
+    );
+    const input = screen.getByLabelText(/기술/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("초기 value 배열이 'a, b, c' 형태로 표시되어야 한다", () => {
+    render(
+      <CommaListField
+        id="test"
+        label="기술"
+        value={["TypeScript", "Next.js"]}
+        onChange={() => {}}
+      />
+    );
+    const input = screen.getByLabelText(/기술/) as HTMLInputElement;
+    expect(input.value).toBe("TypeScript, Next.js");
+  });
+
+  it("한글 항목도 정확히 분리되어야 한다", () => {
+    const onChange = vi.fn();
+    render(
+      <CommaListField id="test" label="태그" value={[]} onChange={onChange} />
+    );
+    const input = screen.getByLabelText(/태그/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "프론트엔드, 백엔드, DB" } });
+    expect(onChange).toHaveBeenCalledWith(["프론트엔드", "백엔드", "DB"]);
+  });
+});
+
+describe("TextField", () => {
+  it("required prop이 별표(*)를 표시해야 한다", () => {
+    render(
+      <TextField id="t" label="이름" value="" onChange={() => {}} required />
+    );
+    expect(screen.getByText("*")).toBeDefined();
+  });
+
+  it("type='date'이면 input type이 date여야 한다", () => {
+    render(
+      <TextField id="t" label="날짜" value="2026-04-30" onChange={() => {}} type="date" />
+    );
+    const input = screen.getByLabelText(/날짜/) as HTMLInputElement;
+    expect(input.type).toBe("date");
+  });
+
+  it("입력 값이 onChange로 전달되어야 한다", () => {
+    const onChange = vi.fn();
+    render(<TextField id="t" label="이름" value="" onChange={onChange} />);
+    const input = screen.getByLabelText(/이름/);
+    fireEvent.change(input, { target: { value: "김코드" } });
+    expect(onChange).toHaveBeenCalledWith("김코드");
+  });
+});
+
+describe("TextAreaField", () => {
+  it("rows prop이 적용되어야 한다", () => {
+    render(
+      <TextAreaField id="t" label="소개" value="" onChange={() => {}} rows={5} />
+    );
+    const textarea = screen.getByLabelText(/소개/) as HTMLTextAreaElement;
+    // happy-dom은 rows를 string으로 보존
+    expect(String(textarea.rows)).toBe("5");
+  });
+
+  it("입력 값이 onChange로 전달되어야 한다", () => {
+    const onChange = vi.fn();
+    render(<TextAreaField id="t" label="소개" value="" onChange={onChange} />);
+    const textarea = screen.getByLabelText(/소개/);
+    fireEvent.change(textarea, { target: { value: "여러줄\n텍스트" } });
+    expect(onChange).toHaveBeenCalledWith("여러줄\n텍스트");
+  });
+});

--- a/apps/web/src/components/admin/form-fields.tsx
+++ b/apps/web/src/components/admin/form-fields.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+
+const INPUT_CLASS =
+  "mt-1 w-full rounded-lg border border-[color:var(--border-mid)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none focus:border-[color:var(--accent)] focus:ring-1 focus:ring-[color:var(--accent)]";
+
+const LABEL_CLASS =
+  "block text-[10px] font-semibold tracking-[0.18em] text-[color:var(--accent)] uppercase";
+
+interface TextFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  type?: "text" | "date";
+  placeholder?: string;
+}
+
+export function TextField({
+  id,
+  label,
+  value,
+  onChange,
+  required,
+  type = "text",
+  placeholder,
+}: TextFieldProps) {
+  return (
+    <div>
+      <label htmlFor={id} className={LABEL_CLASS}>
+        {label}
+        {required && <span className="ml-1 text-[color:var(--error)]">*</span>}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        required={required}
+        placeholder={placeholder}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        className={INPUT_CLASS}
+      />
+    </div>
+  );
+}
+
+interface TextAreaFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  rows?: number;
+  placeholder?: string;
+}
+
+export function TextAreaField({
+  id,
+  label,
+  value,
+  onChange,
+  required,
+  rows = 3,
+  placeholder,
+}: TextAreaFieldProps) {
+  return (
+    <div>
+      <label htmlFor={id} className={LABEL_CLASS}>
+        {label}
+        {required && <span className="ml-1 text-[color:var(--error)]">*</span>}
+      </label>
+      <textarea
+        id={id}
+        value={value}
+        required={required}
+        rows={rows}
+        placeholder={placeholder}
+        onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+        className={`${INPUT_CLASS} resize-none`}
+      />
+    </div>
+  );
+}
+
+interface CommaListFieldProps {
+  id: string;
+  label: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+}
+
+/** 콤마(,)로 구분된 문자열 배열 입력 필드 */
+export function CommaListField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}: CommaListFieldProps) {
+  return (
+    <div>
+      <label htmlFor={id} className={LABEL_CLASS}>
+        {label}
+        <span className="ml-2 text-[10px] font-normal tracking-normal text-[color:var(--text-dim)]">
+          (콤마로 구분)
+        </span>
+      </label>
+      <input
+        id={id}
+        type="text"
+        value={value.join(", ")}
+        placeholder={placeholder}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          const items = e.target.value
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+          onChange(items);
+        }}
+        className={INPUT_CLASS}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/preview/BookPreview.tsx
+++ b/apps/web/src/components/preview/BookPreview.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  getPreviewPayload,
+  type PreviewPagePayload,
+  type PreviewPayloadResult,
+} from "@/lib/api";
+import type { EditSession } from "@/lib/edit-session";
+
+import PageRenderer from "./PageRenderer";
+import { COVER_SPREAD_WIDTH, PAGE_WIDTH } from "./constants";
+import { resolveTemplate } from "./template-resolver";
+
+const TEXT = {
+  title: "책 프리뷰",
+  loading: "프리뷰를 불러오는 중...",
+  error: "프리뷰를 불러오지 못했습니다.",
+  retry: "다시 시도",
+  close: "닫기",
+  prev: "이전",
+  next: "다음",
+  pageOf: (current: number, total: number) => `${current} / ${total}`,
+  emptyPage: "표시할 페이지가 없습니다.",
+  unknownTemplate: "알 수 없는 템플릿입니다.",
+} as const;
+
+interface BookPreviewProps {
+  isOpen: boolean;
+  onClose: () => void;
+  session: EditSession;
+  cohortId: string;
+  studentId?: string;
+}
+
+type FetchStatus = "idle" | "loading" | "success" | "error";
+
+interface PageEntry {
+  payload: PreviewPagePayload;
+  isCover: boolean;
+}
+
+const COVER_CONTAINER_WIDTH = 720;
+const CONTENT_CONTAINER_WIDTH = 400;
+
+export default function BookPreview({
+  isOpen,
+  onClose,
+  session,
+  cohortId,
+  studentId,
+}: BookPreviewProps) {
+  const [status, setStatus] = useState<FetchStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [pages, setPages] = useState<PageEntry[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  // 모달 열릴 때 fetch
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    /* eslint-disable react-hooks/set-state-in-effect -- 모달 open/dependency 변화 시 1회성 초기화 */
+    setStatus("loading");
+    setErrorMessage(null);
+    setCurrentIndex(0);
+    /* eslint-enable react-hooks/set-state-in-effect */
+
+    getPreviewPayload({ session, cohortId, studentId })
+      .then((result: PreviewPayloadResult) => {
+        if (cancelled) return;
+        const entries: PageEntry[] = [
+          { payload: result.cover, isCover: true },
+          ...result.contents.map((p) => ({ payload: p, isCover: false })),
+        ];
+        setPages(entries);
+        setStatus("success");
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setErrorMessage(error instanceof Error ? error.message : TEXT.error);
+        setStatus("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, session, cohortId, studentId]);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      if (e.key === "ArrowLeft") setCurrentIndex((i) => Math.max(0, i - 1));
+      if (e.key === "ArrowRight")
+        setCurrentIndex((i) => Math.min(pages.length - 1, i + 1));
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, onClose, pages.length]);
+
+  if (!isOpen) return null;
+
+  const currentPage = pages[currentIndex];
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={TEXT.title}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex max-h-full w-full max-w-4xl flex-col rounded-2xl bg-[color:var(--surface)] shadow-2xl">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between border-b border-[color:var(--border-soft)] px-6 py-4">
+          <h2 className="font-display text-xl font-bold text-[color:var(--foreground)]">
+            {TEXT.title}
+          </h2>
+          <div className="flex items-center gap-4">
+            {status === "success" && pages.length > 0 && (
+              <span className="text-sm tabular-nums text-[color:var(--text-dim)]">
+                {TEXT.pageOf(currentIndex + 1, pages.length)}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={TEXT.close}
+              className="rounded-lg px-3 py-1.5 text-sm text-[color:var(--text-muted)] hover:bg-[color:var(--surface-elevated)]"
+            >
+              {TEXT.close}
+            </button>
+          </div>
+        </div>
+
+        {/* 메인 — 페이지 렌더링 영역 */}
+        <div className="flex flex-1 items-center justify-center overflow-auto bg-[color:var(--surface-elevated)] p-6">
+          {status === "loading" && (
+            <p className="text-sm text-[color:var(--text-dim)]">{TEXT.loading}</p>
+          )}
+
+          {status === "error" && (
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-sm text-[color:var(--error)]">
+                {errorMessage ?? TEXT.error}
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  // useEffect dependency를 트리거하기 위해 isOpen 토글 대신 직접 fetch
+                  setStatus("loading");
+                  getPreviewPayload({ session, cohortId, studentId })
+                    .then((result) => {
+                      const entries: PageEntry[] = [
+                        { payload: result.cover, isCover: true },
+                        ...result.contents.map((p) => ({
+                          payload: p,
+                          isCover: false,
+                        })),
+                      ];
+                      setPages(entries);
+                      setStatus("success");
+                    })
+                    .catch((err: unknown) => {
+                      setErrorMessage(
+                        err instanceof Error ? err.message : TEXT.error
+                      );
+                      setStatus("error");
+                    });
+                }}
+                className="rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white"
+              >
+                {TEXT.retry}
+              </button>
+            </div>
+          )}
+
+          {status === "success" && currentPage && <RenderedPage entry={currentPage} />}
+
+          {status === "success" && !currentPage && (
+            <p className="text-sm text-[color:var(--text-dim)]">{TEXT.emptyPage}</p>
+          )}
+        </div>
+
+        {/* 푸터 — 네비게이션 */}
+        {status === "success" && pages.length > 1 && (
+          <div className="flex items-center justify-between border-t border-[color:var(--border-soft)] px-6 py-3">
+            <button
+              type="button"
+              onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
+              disabled={currentIndex === 0}
+              aria-label={TEXT.prev}
+              className="rounded-lg px-4 py-2 text-sm font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)] disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              ◀ {TEXT.prev}
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setCurrentIndex((i) => Math.min(pages.length - 1, i + 1))
+              }
+              disabled={currentIndex === pages.length - 1}
+              aria-label={TEXT.next}
+              className="rounded-lg px-4 py-2 text-sm font-semibold text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)] disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              {TEXT.next} ▶
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RenderedPage({ entry }: { entry: PageEntry }) {
+  const resolved = resolveTemplate(entry.payload.templateUid);
+
+  if (!resolved) {
+    return (
+      <p className="text-sm text-[color:var(--text-dim)]">
+        {TEXT.unknownTemplate} ({entry.payload.templateUid})
+      </p>
+    );
+  }
+
+  // 표지는 spread 폭 1716, 내지는 단면 폭 864
+  const containerWidth = entry.isCover
+    ? COVER_CONTAINER_WIDTH
+    : CONTENT_CONTAINER_WIDTH;
+  const templateWidth = entry.isCover ? COVER_SPREAD_WIDTH : PAGE_WIDTH;
+
+  return (
+    <PageRenderer
+      template={resolved.template}
+      params={entry.payload.parameters}
+      containerWidth={containerWidth}
+      templateWidth={templateWidth}
+    />
+  );
+}

--- a/apps/web/src/components/preview/__tests__/BookPreview.test.tsx
+++ b/apps/web/src/components/preview/__tests__/BookPreview.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import BookPreview from "../BookPreview";
+import { TEMPLATES } from "../templates";
+import { createDefaultEditSession } from "@/lib/edit-session";
+
+const PHOTO_URL = "https://example.com/photo.jpg";
+
+const MOCK_PAYLOAD = {
+  cover: {
+    templateUid: TEMPLATES.cover.templateUid,
+    parameters: {
+      coverPhoto: PHOTO_URL,
+      subtitle: "김코드",
+      dateRange: "2026-04-30",
+    },
+  },
+  contents: [
+    {
+      templateUid: TEMPLATES.contentB.templateUid,
+      parameters: {
+        monthNum: "04",
+        dayNum: "25",
+        diaryText: "기념 수료 페이지",
+      },
+    },
+    {
+      templateUid: TEMPLATES.contentA.templateUid,
+      parameters: {
+        monthNum: "04",
+        dayNum: "25",
+        diaryText: "수료생 소개",
+        photo: PHOTO_URL,
+      },
+    },
+  ],
+};
+
+function makeSession() {
+  return createDefaultEditSession("individual", "김코드");
+}
+
+describe("BookPreview", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("isOpen=false", () => {
+    it("isOpen이 false이면 아무것도 렌더링하지 않아야 한다", () => {
+      const { container } = render(
+        <BookPreview
+          isOpen={false}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("성공 케이스", () => {
+    beforeEach(() => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_PAYLOAD,
+      } as Response);
+    });
+
+    it("모달이 dialog role로 렌더링되어야 한다", async () => {
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeDefined();
+      });
+    });
+
+    it("로딩 상태에서 '프리뷰를 불러오는 중...' 텍스트를 표시해야 한다", () => {
+      // fetch가 즉시 resolve되지 않도록 pending Promise
+      globalThis.fetch = vi.fn(() => new Promise<Response>(() => {}));
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      expect(screen.getByText(/프리뷰를 불러오는 중/)).toBeDefined();
+    });
+
+    it("성공 시 페이지 N/M 표시가 1/3이어야 한다 (cover 1 + contents 2)", async () => {
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText("1 / 3")).toBeDefined();
+      });
+    });
+
+    it("다음 버튼 클릭 시 페이지 인덱스가 증가해야 한다", async () => {
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText("1 / 3")).toBeDefined();
+      });
+      fireEvent.click(screen.getByRole("button", { name: "다음" }));
+      expect(screen.getByText("2 / 3")).toBeDefined();
+    });
+
+    it("첫 페이지에서 이전 버튼이 disabled여야 한다", async () => {
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText("1 / 3")).toBeDefined();
+      });
+      const prevBtn = screen.getByRole("button", { name: "이전" });
+      expect(prevBtn).toHaveProperty("disabled", true);
+    });
+
+    it("마지막 페이지에서 다음 버튼이 disabled여야 한다", async () => {
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText("1 / 3")).toBeDefined();
+      });
+      // 끝까지 이동
+      fireEvent.click(screen.getByRole("button", { name: "다음" }));
+      fireEvent.click(screen.getByRole("button", { name: "다음" }));
+      const nextBtn = screen.getByRole("button", { name: "다음" });
+      expect(nextBtn).toHaveProperty("disabled", true);
+    });
+
+    it("닫기 버튼 클릭 시 onClose가 호출되어야 한다", async () => {
+      const onClose = vi.fn();
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={onClose}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeDefined();
+      });
+      fireEvent.click(screen.getByRole("button", { name: "닫기" }));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("에러 케이스", () => {
+    it("fetch 실패 시 에러 메시지와 재시도 버튼을 표시해야 한다", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("네트워크 오류"));
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/네트워크 오류/)).toBeDefined();
+        expect(screen.getByRole("button", { name: "다시 시도" })).toBeDefined();
+      });
+    });
+
+    it("응답이 ok=false면 message를 표시해야 한다", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ message: "기수를 찾을 수 없습니다." }),
+      } as Response);
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="invalid"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/기수를 찾을 수 없습니다/)).toBeDefined();
+      });
+    });
+  });
+
+  describe("알 수 없는 templateUid", () => {
+    it("응답에 알 수 없는 templateUid가 있으면 'unknown' 메시지를 표시해야 한다", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          cover: {
+            templateUid: "UNKNOWN_UID",
+            parameters: {},
+          },
+          contents: [],
+        }),
+      } as Response);
+      render(
+        <BookPreview
+          isOpen={true}
+          onClose={() => {}}
+          session={makeSession()}
+          cohortId="cohort-1"
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/알 수 없는 템플릿/)).toBeDefined();
+      });
+    });
+  });
+});

--- a/apps/web/src/components/preview/__tests__/template-resolver.test.ts
+++ b/apps/web/src/components/preview/__tests__/template-resolver.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTemplate } from "../template-resolver";
+import { TEMPLATES } from "../templates";
+
+describe("resolveTemplate", () => {
+  it("cover templateUid를 isCover=true로 매핑해야 한다", () => {
+    const result = resolveTemplate(TEMPLATES.cover.templateUid);
+    expect(result).not.toBeNull();
+    expect(result?.template.templateUid).toBe(TEMPLATES.cover.templateUid);
+    expect(result?.isCover).toBe(true);
+  });
+
+  it("contentB templateUid를 isCover=false로 매핑해야 한다", () => {
+    const result = resolveTemplate(TEMPLATES.contentB.templateUid);
+    expect(result).not.toBeNull();
+    expect(result?.template.templateUid).toBe(TEMPLATES.contentB.templateUid);
+    expect(result?.isCover).toBe(false);
+  });
+
+  it("contentA templateUid를 isCover=false로 매핑해야 한다", () => {
+    const result = resolveTemplate(TEMPLATES.contentA.templateUid);
+    expect(result?.template.templateUid).toBe(TEMPLATES.contentA.templateUid);
+    expect(result?.isCover).toBe(false);
+  });
+
+  it("gallery templateUid를 isCover=false로 매핑해야 한다", () => {
+    const result = resolveTemplate(TEMPLATES.gallery.templateUid);
+    expect(result?.template.templateUid).toBe(TEMPLATES.gallery.templateUid);
+    expect(result?.isCover).toBe(false);
+  });
+
+  it("알 수 없는 templateUid는 null을 반환해야 한다", () => {
+    expect(resolveTemplate("UNKNOWN_UID")).toBeNull();
+  });
+
+  it("빈 문자열은 null을 반환해야 한다", () => {
+    expect(resolveTemplate("")).toBeNull();
+  });
+});

--- a/apps/web/src/components/preview/template-resolver.ts
+++ b/apps/web/src/components/preview/template-resolver.ts
@@ -1,0 +1,29 @@
+import { TEMPLATES } from "./templates";
+import type { TemplateData } from "./types";
+
+export interface ResolvedTemplate {
+  template: TemplateData;
+  /** 표지(스프레드 뷰)인지 여부 — BookPreview에서 templateWidth 결정에 사용 */
+  isCover: boolean;
+}
+
+/**
+ * 백엔드 payload-mapper가 반환한 templateUid를 정적 저장된 TEMPLATES에 매핑한다.
+ *
+ * 알 수 없는 templateUid는 null 반환 → 호출자가 빈 페이지로 처리하거나 에러 표시.
+ */
+export function resolveTemplate(templateUid: string): ResolvedTemplate | null {
+  if (templateUid === TEMPLATES.cover.templateUid) {
+    return { template: TEMPLATES.cover, isCover: true };
+  }
+  if (templateUid === TEMPLATES.contentB.templateUid) {
+    return { template: TEMPLATES.contentB, isCover: false };
+  }
+  if (templateUid === TEMPLATES.contentA.templateUid) {
+    return { template: TEMPLATES.contentA, isCover: false };
+  }
+  if (templateUid === TEMPLATES.gallery.templateUid) {
+    return { template: TEMPLATES.gallery, isCover: false };
+  }
+  return null;
+}

--- a/apps/web/src/lib/__tests__/api-crud.test.ts
+++ b/apps/web/src/lib/__tests__/api-crud.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createCohort,
+  createProject,
+  createStudent,
+  deleteCohort,
+  deleteProject,
+  deleteStudent,
+  updateCohort,
+  updateProject,
+  updateStudent,
+} from "@/lib/api";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockSuccess<T>(body: T) {
+  vi.mocked(fetch).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function mockError(status: number, message: string) {
+  vi.mocked(fetch).mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ message }),
+  } as Response);
+}
+
+// ────────────────────────────────────────────────
+// Cohort CRUD
+// ────────────────────────────────────────────────
+
+describe("createCohort", () => {
+  it("백엔드 응답의 cohort를 unwrap해서 반환해야 한다", async () => {
+    mockSuccess({
+      cohort: {
+        id: "c1",
+        name: "기수1",
+        program: "프로그램",
+        graduationDate: "2026-04-30",
+        summary: "요약",
+        tagline: "태그",
+        studentCount: 0,
+        students: [],
+      },
+    });
+
+    const result = await createCohort({
+      name: "기수1",
+      program: "프로그램",
+      graduationDate: "2026-04-30",
+      summary: "요약",
+      tagline: "태그",
+    });
+
+    expect(result.id).toBe("c1");
+    expect(result.name).toBe("기수1");
+  });
+
+  it("POST /api/cohorts 경로로 호출해야 한다", async () => {
+    mockSuccess({ cohort: { id: "c1" } });
+    await createCohort({
+      name: "x",
+      program: "x",
+      graduationDate: "2026-01-01",
+      summary: "x",
+      tagline: "x",
+    });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/cohorts");
+    expect(call[1]?.method).toBe("POST");
+  });
+
+  it("실패 시 응답 message를 throw해야 한다", async () => {
+    mockError(400, "name이 필요합니다.");
+    await expect(
+      createCohort({
+        name: "",
+        program: "x",
+        graduationDate: "2026-01-01",
+        summary: "x",
+        tagline: "x",
+      })
+    ).rejects.toThrow("name이 필요합니다.");
+  });
+
+  it("응답 본문에 message가 없으면 기본 메시지를 throw해야 한다", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response);
+    await expect(
+      createCohort({
+        name: "x",
+        program: "x",
+        graduationDate: "2026-01-01",
+        summary: "x",
+        tagline: "x",
+      })
+    ).rejects.toThrow("요청에 실패했습니다.");
+  });
+});
+
+describe("updateCohort", () => {
+  it("PATCH /api/cohorts/:id 경로로 호출해야 한다", async () => {
+    mockSuccess({ cohort: { id: "c1", name: "수정됨" } });
+    await updateCohort("c1", { name: "수정됨" });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/cohorts/c1");
+    expect(call[1]?.method).toBe("PATCH");
+  });
+
+  it("부분 업데이트 body를 그대로 전송해야 한다", async () => {
+    mockSuccess({ cohort: { id: "c1" } });
+    await updateCohort("c1", { name: "신규" });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call[1]?.body).toBe(JSON.stringify({ name: "신규" }));
+  });
+});
+
+describe("deleteCohort", () => {
+  it("DELETE /api/cohorts/:id 경로로 호출해야 한다", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.resolve({}),
+    } as Response);
+    await deleteCohort("c1");
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/cohorts/c1");
+    expect(call[1]?.method).toBe("DELETE");
+  });
+
+  it("204 No Content 응답에서도 throw하지 않아야 한다", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 204,
+      json: () => Promise.resolve({}),
+    } as Response);
+    await expect(deleteCohort("c1")).resolves.toBeUndefined();
+  });
+
+  it("404 응답이면 message를 throw해야 한다", async () => {
+    mockError(404, "기수를 찾을 수 없습니다.");
+    await expect(deleteCohort("invalid")).rejects.toThrow("기수를 찾을 수 없습니다.");
+  });
+});
+
+// ────────────────────────────────────────────────
+// Student CRUD
+// ────────────────────────────────────────────────
+
+describe("createStudent", () => {
+  it("응답의 student를 unwrap해야 한다", async () => {
+    mockSuccess({
+      student: {
+        id: "s1",
+        name: "김코드",
+        roleTrack: "풀스택",
+        bio: "x",
+        techStack: [],
+        projects: [],
+        retrospective: "",
+        mentorComment: "x",
+        photos: [],
+        certificateMessage: "x",
+      },
+    });
+    const result = await createStudent("c1", {
+      name: "김코드",
+      roleTrack: "풀스택",
+      bio: "x",
+      techStack: [],
+      mentorComment: "x",
+      photos: [],
+      certificateMessage: "x",
+    });
+    expect(result.id).toBe("s1");
+  });
+
+  it("POST /api/cohorts/:cohortId/students 경로로 호출해야 한다", async () => {
+    mockSuccess({ student: { id: "s1" } });
+    await createStudent("c1", {
+      name: "x",
+      roleTrack: "x",
+      bio: "x",
+      techStack: [],
+      mentorComment: "x",
+      photos: [],
+      certificateMessage: "x",
+    });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/cohorts/c1/students");
+  });
+});
+
+describe("updateStudent", () => {
+  it("PATCH /api/students/:id 경로로 호출해야 한다", async () => {
+    mockSuccess({ student: { id: "s1", name: "수정됨" } });
+    await updateStudent("s1", { name: "수정됨" });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/students/s1");
+    expect(call[1]?.method).toBe("PATCH");
+  });
+});
+
+describe("deleteStudent", () => {
+  it("DELETE /api/students/:id 경로로 호출해야 한다", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.resolve({}),
+    } as Response);
+    await deleteStudent("s1");
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/students/s1");
+    expect(call[1]?.method).toBe("DELETE");
+  });
+});
+
+// ────────────────────────────────────────────────
+// Project CRUD
+// ────────────────────────────────────────────────
+
+describe("createProject", () => {
+  it("응답의 project를 unwrap해야 한다", async () => {
+    mockSuccess({
+      project: {
+        id: "p1",
+        title: "StudyFlow",
+        summary: "x",
+        contribution: "x",
+        links: [],
+      },
+    });
+    const result = await createProject("s1", {
+      title: "StudyFlow",
+      summary: "x",
+      contribution: "x",
+      links: [],
+    });
+    expect(result.id).toBe("p1");
+    expect(result.title).toBe("StudyFlow");
+  });
+
+  it("POST /api/students/:studentId/projects 경로로 호출해야 한다", async () => {
+    mockSuccess({ project: { id: "p1" } });
+    await createProject("s1", {
+      title: "x",
+      summary: "x",
+      contribution: "x",
+      links: [],
+    });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/students/s1/projects");
+  });
+});
+
+describe("updateProject", () => {
+  it("PATCH /api/projects/:id 경로로 호출해야 한다", async () => {
+    mockSuccess({ project: { id: "p1" } });
+    await updateProject("p1", { title: "수정됨" });
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/projects/p1");
+    expect(call[1]?.method).toBe("PATCH");
+  });
+});
+
+describe("deleteProject", () => {
+  it("DELETE /api/projects/:id 경로로 호출해야 한다", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.resolve({}),
+    } as Response);
+    await deleteProject("p1");
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(String(call[0])).toContain("/api/projects/p1");
+    expect(call[1]?.method).toBe("DELETE");
+  });
+});
+
+// ────────────────────────────────────────────────
+// 공통 — Content-Type 헤더
+// ────────────────────────────────────────────────
+
+describe("CRUD 공통", () => {
+  it("POST 요청은 Content-Type: application/json 헤더를 가져야 한다", async () => {
+    mockSuccess({ cohort: { id: "c1" } });
+    await createCohort({
+      name: "x",
+      program: "x",
+      graduationDate: "2026-01-01",
+      summary: "x",
+      tagline: "x",
+    });
+    const call = vi.mocked(fetch).mock.calls[0];
+    const headers = call[1]?.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("PATCH 요청도 Content-Type 헤더를 가져야 한다", async () => {
+    mockSuccess({ cohort: { id: "c1" } });
+    await updateCohort("c1", { name: "x" });
+    const call = vi.mocked(fetch).mock.calls[0];
+    const headers = call[1]?.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,20 +25,31 @@ export interface CohortDetail extends CohortSummary {
 }
 
 export interface ProjectSummary {
+  id?: string;
   title: string;
   summary: string;
   contribution: string;
   links: string[];
 }
 
+export interface RetrospectiveData {
+  before?: string;
+  process?: string;
+  turning?: string;
+  difficulty?: string;
+  overcome?: string;
+  learned?: string;
+}
+
 export interface StudentPortfolio {
   id: string;
+  cohortId?: string;
   name: string;
   roleTrack: string;
   bio: string;
   techStack: string[];
   projects: ProjectSummary[];
-  retrospective: string;
+  retrospective: string | RetrospectiveData;
   mentorComment: string;
   photos: string[];
   certificateMessage: string;
@@ -112,6 +123,37 @@ export interface OrderResult {
   status: string;
 }
 
+export interface PreviewPagePayload {
+  templateUid: string;
+  parameters: Record<string, string>;
+}
+
+export interface PreviewPayloadResult {
+  cover: PreviewPagePayload;
+  contents: PreviewPagePayload[];
+}
+
+export async function getPreviewPayload(params: {
+  session: EditSession;
+  cohortId: string;
+  studentId?: string;
+}): Promise<PreviewPayloadResult> {
+  const { session, cohortId, studentId } = params;
+
+  const response = await fetch(`${getApiBaseUrl()}/api/preview-payload`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ session, cohortId, studentId }),
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { message?: string };
+    throw new Error(body.message ?? "프리뷰 페이로드를 불러오지 못했습니다.");
+  }
+
+  return (await response.json()) as PreviewPayloadResult;
+}
+
 export async function createBook(params: {
   session: EditSession;
   cohortId: string;
@@ -167,6 +209,153 @@ export async function createOrder(params: {
   }
 
   return (await response.json()) as OrderResult;
+}
+
+// ────────────────────────────────────────────────
+// Cohort CRUD (#77)
+// ────────────────────────────────────────────────
+
+export interface CohortInput {
+  name: string;
+  program: string;
+  graduationDate: string; // YYYY-MM-DD
+  summary: string;
+  tagline: string;
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${getApiBaseUrl()}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string };
+    throw new Error(data.message ?? "요청에 실패했습니다.");
+  }
+  return (await response.json()) as T;
+}
+
+async function patchJson<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${getApiBaseUrl()}${path}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string };
+    throw new Error(data.message ?? "요청에 실패했습니다.");
+  }
+  return (await response.json()) as T;
+}
+
+async function deleteRequest(path: string): Promise<void> {
+  const response = await fetch(`${getApiBaseUrl()}${path}`, { method: "DELETE" });
+  if (!response.ok && response.status !== 204) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string };
+    throw new Error(data.message ?? "삭제에 실패했습니다.");
+  }
+}
+
+export async function createCohort(input: CohortInput): Promise<CohortDetail> {
+  const data = await postJson<{ cohort: CohortDetail }>("/api/cohorts", input);
+  return data.cohort;
+}
+
+export async function updateCohort(
+  cohortId: string,
+  input: Partial<CohortInput>
+): Promise<CohortDetail> {
+  const data = await patchJson<{ cohort: CohortDetail }>(
+    `/api/cohorts/${cohortId}`,
+    input
+  );
+  return data.cohort;
+}
+
+export async function deleteCohort(cohortId: string): Promise<void> {
+  await deleteRequest(`/api/cohorts/${cohortId}`);
+}
+
+// ────────────────────────────────────────────────
+// Student CRUD (#78)
+// ────────────────────────────────────────────────
+
+export interface StudentInput {
+  name: string;
+  roleTrack: string;
+  bio: string;
+  techStack: string[];
+  mentorComment: string;
+  photos: string[];
+  certificateMessage: string;
+}
+
+export async function createStudent(
+  cohortId: string,
+  input: StudentInput
+): Promise<StudentPortfolio> {
+  const data = await postJson<{ student: StudentPortfolio }>(
+    `/api/cohorts/${cohortId}/students`,
+    input
+  );
+  return data.student;
+}
+
+export async function updateStudent(
+  studentId: string,
+  input: Partial<StudentInput>
+): Promise<StudentPortfolio> {
+  const data = await patchJson<{ student: StudentPortfolio }>(
+    `/api/students/${studentId}`,
+    input
+  );
+  return data.student;
+}
+
+export async function deleteStudent(studentId: string): Promise<void> {
+  await deleteRequest(`/api/students/${studentId}`);
+}
+
+// ────────────────────────────────────────────────
+// Project CRUD (#79)
+// ────────────────────────────────────────────────
+
+export interface ProjectInput {
+  title: string;
+  summary: string;
+  contribution: string;
+  links: string[];
+}
+
+export interface ProjectRecord extends ProjectSummary {
+  id: string;
+}
+
+export async function createProject(
+  studentId: string,
+  input: ProjectInput
+): Promise<ProjectRecord> {
+  const data = await postJson<{ project: ProjectRecord }>(
+    `/api/students/${studentId}/projects`,
+    input
+  );
+  return data.project;
+}
+
+export async function updateProject(
+  projectId: string,
+  input: Partial<ProjectInput>
+): Promise<ProjectRecord> {
+  const data = await patchJson<{ project: ProjectRecord }>(
+    `/api/projects/${projectId}`,
+    input
+  );
+  return data.project;
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  await deleteRequest(`/api/projects/${projectId}`);
 }
 
 export async function getStudent(studentId: string) {

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,13 @@
 # 프로젝트 현황
 
-**최종 업데이트:** 2026-04-08 (#87 PageRenderer + 5종 element 컴포넌트)
+**최종 업데이트:** 2026-04-09 (최종 제출 직전 — #88 BookPreview + CRUD UI + 회귀 fix 3건)
 **현재 버전:** v0.1.0
-**배포 URL:** 없음
+**배포 URL:** 없음 (로컬 실행 전용 — #68 프로덕션 배포는 미진행, 별도 후속 작업)
 
 ## 최근 변경
 
+- **CRUD 관리 UI (즉흥 epic, PRD 없음):** #77~#79가 만든 9개 CRUD API에 대응하는 운영자 UI를 추가. `apps/web/src/components/admin/`에 Modal, ConfirmDeleteDialog, form-fields, 3종 FormDialog(Cohort/Student/Project), 4종 AdminPanel 신규. api.ts에 9개 CRUD 함수 + postJson/patchJson/deleteRequest 헬퍼. dashboard·기수 상세·수료생 상세 페이지에 패널 배치, mutation 후 router.refresh()로 자동 갱신. 스코프 작게 유지 — 신규 Json 필드(retrospective, portfolioLinks 등)는 v2. QA에서 form-fields/api-crud/ConfirmDeleteDialog/CohortFormDialog 44개 테스트 추가. 회귀 0건. (devlog: 2026-04-09-crud-admin-ui.md)
+- **#88 BookPreview + EditForm 연결:** payload-mapper 로직 재사용 결정 — **옵션 B (POST /api/preview-payload 신규 엔드포인트)**. 백엔드는 buildCoverPayload+buildContentsPayload 결과를 JSON wrap, 프론트는 모달 열 때 1회 fetch. server.ts에 loadCohortFromDb() 헬퍼 추출하여 /api/books와 공유. BookPreview.tsx + template-resolver.ts 신규, ESC/←/→ 키 지원. EditForm/CohortEditForm에 "프리뷰 보기" 버튼. **회귀 fix 3건 함께 처리**: (1) retrospective Json 객체 React child 에러 (#82 머지 후 student 상세 페이지 깨진 채로 방치), (2) 502 collagePhotos 이중 인코딩 (payload-mapper가 string화 + sweetbook-api가 또 stringify → SweetBook이 0장 인식, sweetbook-api에서 JSON 문자열 parse hack), (3) GET /api/students/:id 응답에 cohortId 필드 추가. 테스트 322개. (devlog: 2026-04-09-issue-88-book-preview.md)
 - **#87 PageRenderer + 5종 element 컴포넌트:** `apps/web/src/components/preview/`에 PageRenderer.tsx + elements/ 5종(Text/Photo/Graphic/Rectangle/Collage) + utils/ 3종(color ARGB→rgba, font 매핑, scale). globals.css에 6종 Google Fonts 단일 import 추가. GraphicElement는 #85 결정대로 imageSource 무시하고 단색 div fallback. CollageElement는 사진 수별 정적 grid 규칙. QA에서 색상 변환 DOM 반영 + GraphicElement img 태그 회귀 방지 + PageRenderer 비정상 입력 방어 테스트 추가. 테스트 305개(+77).
 - **#86 프리뷰 템플릿 데이터 정적 저장:** `apps/web/src/components/preview/` 신규 디렉토리. types.ts(5종 element discriminated union), constants.ts(PAGE_WIDTH/HEIGHT, GRAPHIC_FALLBACK_COLOR), templates.ts(4개 템플릿 정적 저장 — cover/contentB/contentA/gallery), param-substitute.ts(`$$key$$` 치환 유틸). QA에서 templates.ts ↔ payload-mapper 파라미터 8종 정합성 테스트 추가 — #87 구현 시 가정 일치 보장. 테스트 228개(+37).
 - **#85 책 프리뷰 선행 검증:** 3개 외부 의존성 확인. (1) 그래픽 이미지(`/api_platform_image/...`) 외부 접근 **불가** → CSS 단색 div 대체 결정. (2) Google Fonts 6종(Do Hyeon, Nanum Myeongjo, DM Serif Display 등) 모두 **가용**. (3) collageGallery는 PRD가 가정한 `flow.columns` 대신 `layout:"auto"` 블랙박스 — 사진 수별 정적 그리드 규칙으로 fallback. `/v1/templates/{uid}` 엔드포인트는 정상 동작 확인되어 #86 templates.ts 정적 저장 가능.
@@ -51,10 +53,11 @@
 | 이슈 | 심각도 | 상태 |
 |------|-------|------|
 | ~~내지 모든 페이지에 동일 파라미터(이름만) 반복 — 실제 콘텐츠 미반영~~ | ~~높음~~ | 해결 (#82) |
-| SweetBook API 프리뷰/PDF 미지원 — 책 결과물 확인 불가 | 높음 | 진행 예정 (#85~#88) |
-| DB 없음 — CRUD 불가, 시연 시 데이터 조작 불가 | 높음 | 진행 예정 (#74~#80) |
-| server.ts 라우트 핸들러 테스트 0개 | 중간 | #76 구현 시 해결 |
-| `jsdom@29` + Vitest 최신 버전 ESM 호환 이슈로 컴포넌트 테스트 환경 미구성 | 낮음 | 완료 (happy-dom 도입) |
+| ~~SweetBook API 프리뷰/PDF 미지원 — 책 결과물 확인 불가~~ | ~~높음~~ | 해결 (#85~#88, 자체 HTML 렌더러) |
+| ~~DB 없음 — CRUD 불가, 시연 시 데이터 조작 불가~~ | ~~높음~~ | 해결 (#74~#80 + CRUD UI epic) |
+| server.ts 라우트 핸들러 통합 테스트 0개 | 중간 | 별도 이슈 — supertest 인프라 구축 필요 |
+| collagePhotos 이중 인코딩 hack (sweetbook-api.ts) | 낮음 | 임시 fix — 정식 fix는 ContentPagePayload.parameters 타입을 `Record<string, string \| string[]>`로 확장 |
+| ~~`jsdom@29` + Vitest 최신 버전 ESM 호환 이슈로 컴포넌트 테스트 환경 미구성~~ | ~~낮음~~ | 완료 (happy-dom 도입) |
 
 ## 기술 부채
 
@@ -63,6 +66,9 @@
 | ~~payload-mapper가 블록 ID를 무시하고 동일 파라미터 복사~~ | 2026-04-08 | ~~L~~ 완료 (#82) |
 | ~~정적 JSON 데이터 → PostgreSQL 전환 필요~~ | 2026-04-08 | ~~M~~ 완료 (#74~#76) |
 | ~~PRD 24페이지 구성표에 필요한 데이터 필드 누락~~ | 2026-04-08 | ~~M~~ 완료 (#75 seed) |
+| ContentPagePayload.parameters를 `Record<string, string \| string[]>`로 정식 확장 | 2026-04-09 | M (#88 hack 제거) |
+| CRUD UI에 신규 Json 필드 입력 (retrospective 6필드, portfolioLinks 4필드, project problem/solution/result) | 2026-04-09 | M (v2) |
+| StudentFormDialog/ProjectFormDialog 단위 테스트 (CohortFormDialog와 패턴 동일) | 2026-04-09 | S |
 | pnpm 기준 README 실행 절차를 실제 dev 서버 구동 기준으로 검증 | 2026-04-04 | S |
 
 ## 다음 계획
@@ -82,14 +88,24 @@
 - [x] `#83` 프론트엔드 블록 ID 확장 [M] → depends: #82
 - [x] `#84` EditForm 새 블록 타입 UI [M] → depends: #83
 
-### Epic: 책 프리뷰 렌더러 (#85~#88)
+### Epic: 책 프리뷰 렌더러 (#85~#88) — 완료
 - [x] `#85` 프리뷰 선행 검증 [S] — 독립 (동시 시작 가능)
 - [x] `#86` 템플릿 레이아웃 데이터 정적 저장 [M] → depends: #85
 - [x] `#87` PageRenderer 컴포넌트 [L] → depends: #86
-- [ ] `#88` BookPreview + EditForm 연결 [M] → depends: #87, #82
+- [x] `#88` BookPreview + EditForm 연결 [M] → depends: #87, #82
 
-### 배포
+### Epic: CRUD 관리 UI — 완료 (PRD 없는 즉흥 작업)
+- [x] CohortFormDialog/CohortAdminPanel + 대시보드 배치
+- [x] StudentFormDialog/StudentAdminPanel/StudentEditDeletePanel + 기수·수료생 상세 배치
+- [x] ProjectFormDialog/ProjectAdminPanel + 수료생 상세 배치
+- [x] api.ts CRUD 9개 함수 + 공통 헬퍼
+- [x] form-fields/ConfirmDeleteDialog 공통 컴포넌트
+- [x] QA 44개 테스트
+
+### 배포 — 미진행
 - [ ] `#68` Vercel + Railway 프로덕션 배포 [M] → depends: #76
+  - **상태:** 미진행. 이번 사이클에서는 로컬 + Docker Compose 실행만 검증.
+  - 의존성(#76 DB 전환, #74 Docker Compose)은 모두 완료되어 있어 작업 자체는 가능하나, 시연·평가 흐름을 위한 단일 PR 마무리가 우선이라 후순위로 둠.
 
 ### 미머지 PR (기존)
 - [x] `#67` 구조화 로깅 DoD 완료 — PR 머지 대기

--- a/docs/devlog/2026-04-09-crud-admin-ui.md
+++ b/docs/devlog/2026-04-09-crud-admin-ui.md
@@ -1,0 +1,88 @@
+# 개발 일지: CRUD 관리 UI (운영자 대시보드)
+
+**일자:** 2026-04-09
+**관련 이슈:** 없음 (PRD/이슈 분해 없이 즉흥 추가)
+**관련 역할:** build, qa
+
+## 배경 (Context)
+
+#77~#79에서 Cohort/Student/Project 9개 CRUD API 엔드포인트를 만들었지만, 그 위에 올릴 UI가 없는 채로 #80~#88까지 진행되었다. 즉 백엔드 CRUD는 dead code처럼 존재했고, 데이터는 seed 스크립트로만 들어갔다. 사용자가 #88 작업 중 "근데 우리가 만들었던 CRUD에 대한 UI가 없네?"라고 지적하면서 발견. 평가:
+
+- MVP 시연에서 운영자가 직접 기수→수료생→프로젝트를 등록하고 그걸로 책 만드는 흐름이 **진짜 풀스택의 가치**를 보여준다.
+- seed에만 의존하면 백엔드 9개가 정말 dead처럼 보인다.
+- 1인 개발자 5원칙 #1 "나중에는 거짓말이다" — v2로 미루면 영영 안 함.
+
+## 작업 결정
+
+### 정식 절차 vs 즉흥 진행
+
+평소라면 `/spec`을 호출해 PRD를 만들고 이슈로 분해한 뒤 epic으로 진행하는 게 옳다. 그러나 사용자가 "지금 브랜치에서 바로 작업해줘"라고 명시. #88 PR이 이미 commit 안 된 fix들로 부풀어 있었지만, **컨텍스트가 같은 영역(CRUD↔책 생성 흐름)이고 1인 개발이라 리뷰 부담은 본인이 진다**는 점에서 즉흥 진행을 수용. 단, devlog로라도 결정 배경과 스코프를 박아두기로 함.
+
+### 스코프: 작게 유지 (v1에 정말 필요한 것만)
+
+각 모델의 모든 필드를 폼에 받지 않는다. 책 렌더링 fallback이 있는 신규 필드는 v2로:
+
+| 모델 | 폼 포함 | 폼 제외 (v2) |
+|------|--------|------------|
+| Cohort | name, program, graduationDate, summary, tagline | operatorMessage, philosophy, logoUrl, photos[], partnerInfo, stats |
+| Student | name, roleTrack, bio, techStack, mentorComment, photos, certificateMessage | retrospective Json, interests, achievements, portfolioLinks, thanksMessage |
+| Project | title, summary, contribution, links | problem, solution, techChoices, result |
+
+`techStack`/`photos`/`links`처럼 string[] 필드는 콤마 분리 단일 입력(`CommaListField`)으로. JSON 객체 필드(`retrospective` 6필드, `portfolioLinks` 4필드)는 v1 폼에서 제외 — 책 매퍼에 fallback이 모두 있어 비어있어도 동작한다.
+
+### UX 패턴
+
+- **모달 형태**: 별도 라우트 없이 같은 페이지에 다이얼로그. ESC 닫기, 배경 클릭 닫기.
+- **생성/수정 통합 다이얼로그**: 같은 컴포넌트가 `initial` prop 유무로 mode 분기. `isEdit = Boolean(initial?.id)`.
+- **삭제 별도 confirm**: `ConfirmDeleteDialog`로 한 번 더 확인. **API 실패 시 모달이 닫히지 않고 에러 표시** (사용자가 무슨 일이 일어났는지 알아야 함).
+- **mutation 후 `router.refresh()`**: 클라이언트 state 추가 관리 없이 Next.js가 server component를 재실행하여 자동 데이터 갱신.
+
+### 폴더 구조
+
+```
+apps/web/src/components/admin/
+  ├── Modal.tsx                    공통 모달 + ESC 닫기
+  ├── ConfirmDeleteDialog.tsx      삭제 확인 + 에러 처리
+  ├── form-fields.tsx              TextField, TextAreaField, CommaListField
+  ├── CohortFormDialog.tsx         생성/수정 통합
+  ├── StudentFormDialog.tsx        생성/수정 통합
+  ├── ProjectFormDialog.tsx        생성/수정 통합
+  ├── CohortAdminPanel.tsx         대시보드용
+  ├── StudentAdminPanel.tsx        기수 상세용
+  ├── StudentEditDeletePanel.tsx   수료생 상세 헤더 (수정/삭제)
+  └── ProjectAdminPanel.tsx        수료생 상세용
+```
+
+`api.ts`에 9개 CRUD 함수 + 공통 헬퍼(`postJson`/`patchJson`/`deleteRequest`) 추가. 백엔드가 `{ cohort: {...} }` / `{ student: {...} }` / `{ project: {...} }`로 wrap해 응답하므로 함수 안에서 unwrap.
+
+## 시도한 것들 (Attempts)
+
+1. **공통 헬퍼 추출 vs 함수마다 fetch**: 처음엔 9개 함수 각각에 fetch+에러처리를 인라인으로 쓰려 했으나, 헬퍼 3개(`postJson`/`patchJson`/`deleteRequest`)로 묶으니 9개 함수가 평균 5줄로 압축됨. 응답 wrapping과 에러 추출이 한 곳에 모이므로 회귀 위험도 낮음.
+2. **수료생 수정 위치**: 처음엔 cohort 상세에 수정 모달까지 넣으려 했으나, 수료생 폼이 7개 필드라 cohort 상세에 모달이 들어가면 너무 무거워짐. **수료생 수정/삭제는 수료생 상세 페이지(`/students/[id]`)의 헤더 액션으로 분리**(`StudentEditDeletePanel`). 삭제 후엔 cohort 페이지로 자동 이동.
+3. **백엔드 응답 보강**: GET `/api/students/:id` 응답에 `cohortId`가 빠져있어, 수료생 수정/삭제 후 어디로 돌아갈지 알 수 없었다. 백엔드 응답에 `cohortId` 한 줄 추가 + 프론트 `StudentPortfolio` 타입 동기화. 같은 김에 `projects[].id`도 응답에 추가했다 (CRUD 대상 식별).
+
+## QA 결과
+
+| 영역 | 테스트 | 검증 |
+|------|------|------|
+| `form-fields` | 12 | CommaListField 분리/trim/빈 항목 제거/한글 포함 |
+| `api-crud` | 18 | 9개 함수의 경로/메서드/응답 unwrap/에러 처리/Content-Type |
+| `ConfirmDeleteDialog` | 6 | API 실패 시 모달 유지 + 에러 표시 (가장 위험한 회귀 방지) |
+| `CohortFormDialog` | 8 | create/edit 분기 — `initial.id` 유무로 POST vs PATCH |
+
+총 +44개 테스트, 367개 통과. 발견된 버그 0건. happy-dom 차이 1건만 테스트 코드에서 흡수.
+
+## 배운 것 (Lessons Learned)
+
+- **백엔드에 dead endpoint를 만들지 말 것.** #77~#79가 만들어진 시점에 UI까지 함께 epic으로 묶었어야 했다. 백엔드 9개 + 한참 뒤에 UI 0개 상태가 4-5번 머지 동안 유지됐고, 사용자가 명시적으로 지적할 때까지 발견 못했다. 다음 epic은 "API + UI"를 한 단위로 묶을 것.
+- **PRD 없는 즉흥 작업의 부작용 vs 가치**. 정식 절차(`/spec` → 이슈 분해 → 작은 PR 여러 개)를 건너뛴 대가는 PR이 거대해지고 리뷰 부담이 커진다는 점. 반면 컨텍스트가 살아있을 때 한 번에 끝낸 가치는 분명. **1인 개발자라 trade-off가 본인에게 돌아오므로** 즉흥 진행 자체는 합리적이지만, devlog로라도 결정 배경을 박아두지 않으면 미래의 본인이 "왜 이게 한 PR에 다 들어왔지"를 이해 못 한다.
+- **router.refresh() 패턴이 강력하다.** mutation 후 자체 state 동기화 없이 server component를 재실행하면 데이터 일관성이 자동 보장됨. 클라이언트 캐시 관리 코드가 0줄. Next.js App Router의 가장 큰 장점.
+- **콤마 분리 입력 vs 다중 input**. `CommaListField`는 빠르게 만들 수 있지만 사용성이 거칠다 (콤마를 빠뜨리면 안 됨). v2에서 chip input으로 개선 후순위로 등록.
+
+## v2 후순위 (TODO)
+
+- 신규 필드 입력 UI: retrospective Json 6필드, portfolioLinks 4필드, project의 problem/solution/techChoices/result
+- ChipInput 컴포넌트로 콤마 분리 입력 대체
+- 권한/인증 (현재 모든 사용자가 CRUD 가능)
+- Optimistic UI (router.refresh 대신)
+- StudentFormDialog/ProjectFormDialog의 단위 테스트 (CohortFormDialog와 패턴 동일하므로 우선순위 낮음)

--- a/docs/devlog/2026-04-09-issue-88-book-preview.md
+++ b/docs/devlog/2026-04-09-issue-88-book-preview.md
@@ -1,0 +1,69 @@
+# 개발 일지: #88 BookPreview 컨테이너 + 회귀 fix 3건
+
+**일자:** 2026-04-09
+**관련 이슈:** #88
+**관련 역할:** build, qa
+
+## 배경 (Context)
+
+#85~#87에서 PageRenderer + 4개 템플릿 정적 데이터를 만들었으니, 이제 사용자가 실제로 책을 미리 볼 수 있는 컨테이너(BookPreview)와 EditForm 진입점이 필요했다. 이 작업 자체는 PRD §3.5, §4.3 그대로 구현하면 되지만, 실제로 페이지를 열어보니 #82 이후 누적된 회귀 버그 3건이 한꺼번에 드러났다.
+
+## 핵심 결정: payload-mapper 로직을 어떻게 재사용할 것인가
+
+프리뷰는 책 생성과 똑같이 페이지별 파라미터를 만들어야 한다. 백엔드 `payload-mapper.ts`(398줄, 12종 페이지 매퍼)를 어떻게 재사용할지가 #88 최대 결정이었다.
+
+| 옵션 | 평가 |
+|------|------|
+| A. 백엔드 로직을 프론트에 복사 | 빠르지만 #83에서 이미 한 번 회귀(레거시 ID 미동기화) 발생. 매퍼가 12종으로 늘어 양쪽 동기화 부담이 큼. |
+| **B. POST /api/preview-payload 신규 엔드포인트** | payload-mapper가 단일 진실. #82 정합성 테스트가 그대로 적용. 모달 열 때 1회 fetch라 네트워크 비용 미미. |
+| C. packages/ 공유 패키지 추출 | 모노레포 구조 변경 필요, #88 범위 초과. |
+
+**B 선택.** `server.ts`의 `/api/books` 핸들러에 있던 DB→Cohort[] 변환 로직을 `loadCohortFromDb()` 헬퍼로 추출하고, `/api/preview-payload`가 이를 재사용해서 `buildCoverPayload + buildContentsPayload` 결과를 그대로 JSON으로 반환한다. 프론트의 `BookPreview`는 모달이 열릴 때 한 번 fetch하고, 응답의 `templateUid`를 `template-resolver.ts`로 정적 `TEMPLATES` 객체에 매핑한 뒤 PageRenderer에 전달.
+
+## 발견된 회귀 버그 3건
+
+브라우저에서 처음 페이지를 열어보니 PRD §3.5/§4.3 외에 3개의 별도 회귀가 한꺼번에 나왔다. 모두 #82 머지 이후에 잠재되어 있었고, 이번에 처음으로 production-like 흐름이 동작하면서 드러난 것들.
+
+### Bug 1: retrospective Json 객체가 React child로 렌더링됨
+
+**증상:** `/students/student-001` 페이지가 `Objects are not valid as a React child` 런타임 에러로 깨짐.
+
+**원인:** #82에서 백엔드 `Student.retrospective`를 `string`에서 `string | RetrospectiveData(6필드 객체)`로 확장했지만, 프론트의 `apps/web/src/lib/api.ts`의 `StudentPortfolio.retrospective` 타입과 `students/[studentId]/page.tsx`의 `{student.retrospective}` 직접 렌더링은 `string` 가정 그대로였다. 그동안 mock data만 사용했기 때문에 미발견.
+
+**수정:** api.ts에 `RetrospectiveData` 타입 추가 + page.tsx에 `formatRetrospective()` 헬퍼 추가하여 객체이면 6개 필드를 공백으로 합쳐 텍스트로 변환.
+
+### Bug 2: 502 Bad Gateway — collagePhotos 이중 인코딩
+
+**증상:** "내지 추가" 단계에서 SweetBook이 `"collagePhotos는 1~9장의 사진이 필요합니다. (현재: 0장)"` 400 에러 반환.
+
+**원인:** `payload-mapper.ts:galleryPage`가 `ContentPagePayload.parameters: Record<string, string>` 타입 제약 때문에 `collagePhotos: JSON.stringify(photos)`로 배열을 문자열화했고, 그 다음 `sweetbook-api.ts:addContentsPage`가 `JSON.stringify(payload.parameters)`로 parameters 객체 전체를 또 한 번 직렬화. **결과는 `collagePhotos` 값이 escape된 문자열 `"[\"url1\",\"url2\"]"`** — SweetBook이 배열로 파싱하지 못해 0장으로 인식. payload-mapper 단위 테스트는 매퍼 결과만 검증했고 실제 SweetBook 호출은 안 했기 때문에, #81 검증(raw curl) → #82 매퍼 단위 테스트 → #87 PageRenderer 통합 어디서도 잡지 못함.
+
+**수정 (옵션 A — hack):** `sweetbook-api.ts:addContentsPage`에서 parameters를 직렬화하기 전, 값이 `[...]` 형태 문자열이면 한 번 parse해서 배열로 복원. 변경 범위가 5줄이라 즉시 해결 가능. 정식 fix(타입을 `Record<string, string | string[]>`로 확장)는 다른 array 파라미터(`photos[]` 등)가 추가될 때 별도 리팩토링 이슈로 진행 권장 — 현재 코드에 명시 주석 표시.
+
+### Bug 3: EditForm 토글 회귀 (#84에서 이미 수정됨)
+
+#83 머지 직후부터 EditForm 토글이 레거시 ID(`project:N`)와 새 ID(`project-summary:N`)가 매칭 안 되어 사실상 무효였던 버그. #84에서 PageBlockList 추출과 함께 수정 완료. 이 회귀는 데이터 스키마와 UI를 따로 머지한 게 원인이었다.
+
+## 시도한 것들
+
+1. **모달 fetch 패턴**: useEffect 안에서 fetch 호출. React 19의 `react-hooks/set-state-in-effect` 린트 경고가 떴지만, 모달 open/dependency 변화 시 1회성 초기화는 안전하므로 명시적 disable comment.
+2. **template-resolver로 정적 매핑**: 백엔드가 templateUid 문자열을 보내고 프론트가 4개 정적 TEMPLATES 객체에 매핑. 알 수 없는 UID는 null 반환 → BookPreview가 "알 수 없는 템플릿" 메시지 표시.
+3. **표지 vs 내지 컨테이너 폭 분기**: 표지는 spread(1716)이고 내지는 단면(864)이므로 `isCover` 플래그로 templateWidth 결정.
+
+## 최종 해결
+
+- `apps/api/src/server.ts`: `loadCohortFromDb()` 추출 + `POST /api/preview-payload` 라우트
+- `apps/api/src/lib/sweetbook-api.ts`: collagePhotos 이중 인코딩 hack fix
+- `apps/web/src/components/preview/BookPreview.tsx`: 모달 + 페이지 네비 + 키보드(Esc/←/→)
+- `apps/web/src/components/preview/template-resolver.ts`: templateUid → TEMPLATES 매핑
+- `apps/web/src/lib/api.ts`: `getPreviewPayload` + `RetrospectiveData` + `StudentPortfolio.cohortId/retrospective` 타입 확장
+- `apps/web/src/app/students/[studentId]/page.tsx`: `formatRetrospective()` 헬퍼
+- EditForm/CohortEditForm에 "프리뷰 보기" 버튼
+- 테스트 21개 신규 (template-resolver 6 + BookPreview 15)
+
+## 배운 것 (Lessons Learned)
+
+- **단위 테스트가 SweetBook API 호출을 모킹하면 실제 직렬화 버그를 못 잡는다.** payload-mapper 매퍼 테스트는 `parameters.collagePhotos`가 JSON 문자열이어도 통과한다 — 왜냐하면 테스트가 `JSON.parse()`로 검증하기 때문. 그러나 실제 sweetbook-api.ts는 이 문자열을 객체에 넣어 한 번 더 stringify한다. **외부 API와 실제로 한 번 호출해보는 검증(#81 sandbox 검증 같은)이 단위 테스트와 별개로 가치가 있다.** 다만 #81 때는 raw curl로 호출했기 때문에 production 코드 경로를 안 거쳤다 — 이게 함정이었다.
+- **데이터 스키마 변경은 호출부까지 같은 PR에서 검증해야 한다.** Bug 1(retrospective)과 Bug 3(레거시 ID)이 모두 같은 패턴 — 백엔드/타입은 바꿨지만 UI 호출부는 안 바꿔서 컴파일은 통과해도 런타임에서 깨짐. 이번 PR에서 발견된 게 그나마 다행이고, 미래에는 머지 전에 페이지를 직접 한 번 열어보는 절차를 추가할 만하다.
+- **모달 fetch는 의외로 단순한 패턴**이지만 React 19 린트 규칙(`set-state-in-effect`)이 까다롭다. 모달 open 시 1회성 초기화는 의도적인 패턴이므로 disable comment로 명시 — 단, comment에 "왜 disable했는지" 같이 적기.
+- **payload-mapper를 API로 wrapping(옵션 B)이 옳았다.** 옵션 A(코드 복사)였다면 #82~#84에 추가된 정합성 테스트 모음을 프론트에 또 만들거나, 동기화 부담을 떠안았을 것이다. 단일 진실 원칙은 1인 개발자에게 특히 중요.


### PR DESCRIPTION
## 📌 변경 요약

#88 BookPreview 컨테이너 구현 + 누적된 회귀 버그 3건 fix + #77~#79 백엔드 CRUD에 대응하는 운영자 UI 추가. **최종 제출 직전 마무리 PR**입니다.

## 🔗 관련 이슈 / PRD

Closes #88
PRD: \`docs/prd/book-preview-renderer.md\` (§3.5, §4.3)
관련 devlog:
- \`docs/devlog/2026-04-09-issue-88-book-preview.md\`
- \`docs/devlog/2026-04-09-crud-admin-ui.md\`

## 🧱 변경 범위

- [x] 새로운 기능 (feature) — #88 BookPreview, CRUD UI
- [x] 버그 수정 (bug fix) — 회귀 3건
- [x] 문서 수정 (docs)

## 🔧 주요 변경점

### 1) #88 BookPreview + 프리뷰 엔드포인트
- \`POST /api/preview-payload\` 신규 (loadCohortFromDb 헬퍼 추출 → /api/books와 공유)
- \`BookPreview.tsx\` 모달 + 페이지 네비게이션 (ESC/←/→)
- \`template-resolver.ts\` 정적 매핑
- EditForm/CohortEditForm에 '프리뷰 보기' 버튼
- **payload-mapper 단일 진실 유지**를 위해 옵션 B (API wrapping) 채택. 옵션 A(코드 복사)는 #82~#84 정합성 테스트 동기화 부담이 커서 기각.

### 2) 회귀 fix 3건
- **retrospective Json React child 에러**: #82에서 백엔드 retrospective를 \`string → string|6필드객체\`로 확장했지만 student 상세 페이지가 \`{student.retrospective}\`로 직접 렌더링하던 회귀. \`formatRetrospective()\` 헬퍼 추가.
- **502 collagePhotos 이중 인코딩**: payload-mapper가 \`JSON.stringify(photos)\`로 string화 → sweetbook-api가 또 \`JSON.stringify(parameters)\` → SweetBook이 0장으로 인식하여 400. sweetbook-api에서 \`[...]\` 형태 문자열을 parse 후 객체로 복원하는 임시 hack. 정식 fix(타입 확장)는 별도 기술 부채로 등록.
- **GET /api/students/:id 응답에 cohortId 누락**: 수료생 수정/삭제 후 어디로 돌아갈지 알 수 없었음. 응답에 cohortId 추가.

### 3) CRUD 관리 UI (PRD 없는 즉흥 epic)
- \`apps/web/src/components/admin/\` 신규 (10개 컴포넌트)
- 3종 FormDialog (create/edit 통합), 4종 AdminPanel
- api.ts에 9개 CRUD 함수 + 공통 헬퍼
- mutation 후 \`router.refresh()\`로 자동 데이터 갱신
- **스코프 작게**: 신규 Json 필드(retrospective 6필드, portfolioLinks 등)는 v2 후순위

## 🧪 검증

- [x] 로컬에서 정상 동작을 확인했습니다 (사용자 수동 검증 — 책 생성까지 E2E 통과)
- [x] 관련 테스트를 추가하거나 업데이트했습니다
- [x] 문서를 업데이트했습니다 (해당하는 경우)

수동 검증:
- \`pnpm --filter api run build\` ✅
- \`pnpm --filter web run lint\` ✅
- \`pnpm --filter web exec tsc --noEmit\` ✅
- 책 생성 흐름 E2E 수동 검증 (502 fix 후 \`bookUid: bk_mJPkempnaVDK\` 정상 생성 확인)

자동 검증:
- API 154개 테스트 통과
- Web 367개 테스트 통과 (BookPreview 15 + template-resolver 6 + CRUD UI 44 신규)
- **합계 521개 테스트 통과**

## 📸 UI / API 영향

- UI 변경:
  - 모든 페이지에 CRUD 운영자 패널 추가 (대시보드, 기수 상세, 수료생 상세)
  - 편집 화면에 '프리뷰 보기' 버튼 → 모달
- API 변경:
  - \`POST /api/preview-payload\` 신규 (조회만, Idempotency-Key 불필요)
  - \`GET /api/students/:id\` 응답에 cohortId 필드 추가 (하위 호환)
  - \`POST /api/books\`에서 SweetBook collagePhotos 호출이 정상화됨 (502 → 200)
- 데이터 모델 변경: 없음

## ✅ 체크리스트

- [x] 로컬에서 정상 동작을 확인했습니다
- [x] 관련 테스트를 추가하거나 업데이트했습니다
- [x] 문서를 업데이트했습니다 (해당하는 경우)

## ⚠️ 주의사항

- **PR 크기가 큼** (코드 1700줄+ / 테스트 1000줄+ / 문서 200줄+). 회귀 fix와 CRUD UI가 같은 작업 흐름에서 발견·해결되었고 1인 개발 컨텍스트라 단일 PR로 마무리. 커밋 단위(feat/test/docs 3개)로 리뷰 가능.
- **collagePhotos 이중 인코딩 fix는 임시 hack**입니다. 정식 fix(\`ContentPagePayload.parameters\`를 \`Record<string, string | string[]>\`로 확장)는 별도 기술 부채로 등록 — 다른 array 파라미터 추가 시 우선 진행.
- **server.ts 라우트 핸들러 통합 테스트는 0개** 유지(STATUS 알려진 이슈). #88 preview-payload 라우트도 마찬가지로 직접 테스트 없이 프론트 통합 시나리오로 커버.
- **CRUD UI는 PRD 없이 즉흥 진행**되었습니다. 결정 배경은 devlog에 박혀있음.
- **실제 배포는 진행하지 않았습니다** (#68 후순위). 로컬 + Docker Compose 실행만 검증.